### PR TITLE
Fix episode merging logic in join_episodes.clj

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,2681 +1,3218 @@
-[ {
-  "title" : "William H. Mumler, Geisterfotograf",
-  "tag" : "gag505",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000710093433",
-  "url_spotify" : "https://open.spotify.com/episode/5OanQii9TMvgUjMBCqBa33"
-}, {
-  "title" : "Die Schlacht bei Kadesch",
-  "tag" : "gag503",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000708420848",
-  "url_spotify" : "https://open.spotify.com/episode/7ubzOCUdeRKGqbgyMb6kTO"
-}, {
-  "title" : "Wie die Jeans entstand",
-  "tag" : "gag501",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000705259164",
-  "url_spotify" : "https://open.spotify.com/episode/4WnNgboTbMJ4UjGg36sv7n"
-}, {
-  "title" : "Die wendungsreiche Karriere eines deutschen Revolutionärs in den USA",
-  "tag" : "gag499",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000703566297",
-  "url_spotify" : "https://open.spotify.com/episode/7A5z3wlYSYzodLLIge6TdU"
-}, {
-  "title" : "Drais und die Laufmaschine",
-  "tag" : "gag497",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000701734752",
-  "url_spotify" : "https://open.spotify.com/episode/387dmYlSSmi5WUeKnmno2X"
-}, {
-  "title" : "Das Bandoneon und der Tango",
-  "tag" : "gag495",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000699708149",
-  "url_spotify" : "https://open.spotify.com/episode/4JEP3nviQi5OzZjEmYdd83"
-}, {
-  "title" : "Kernspaltung und Schwerwasser-Sabotage",
-  "tag" : "gag493",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000697649337",
-  "url_spotify" : "https://open.spotify.com/episode/4cYBmGEXd9PyghDbAEq3Q9"
-}, {
-  "title" : "Die Dreyfus-Affäre",
-  "tag" : "gag491",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000693716547",
-  "url_spotify" : "https://open.spotify.com/episode/4w6cJaI1YCPxgy4dGsRPbW"
-}, {
-  "title" : "Eunus und der erste Sklavenkrieg",
-  "tag" : "gag490",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000691103614",
-  "url_spotify" : "https://open.spotify.com/episode/4XZRoBAiqQZeS5HZ4JjfFm"
-}, {
-  "title" : "Hokusai und die Große Welle",
-  "tag" : "gag488",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000685848829",
-  "url_spotify" : "https://open.spotify.com/episode/2qbnOfXhNDkgLD5LnIPppu"
-}, {
-  "title" : "Professor Porta und das Ende der Welt",
-  "tag" : "gag486",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000683806667",
-  "url_spotify" : "https://open.spotify.com/episode/7h5EfEpmXaBiIBEJFUtTOD"
-}, {
-  "title" : "Emil Berliner und die Erfindung der Musikindustrie",
-  "tag" : "gag484",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000682218521",
-  "url_spotify" : "https://open.spotify.com/episode/2kC72lwL4qZQu5JlebpU43"
-}, {
-  "title" : "Sarawak und die Dynastie der Weißen Rajahs",
-  "tag" : "gag482",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000680709654",
-  "url_spotify" : "https://open.spotify.com/episode/3pvxRGTplNCoAR2fRCwmJh"
-}, {
-  "title" : "Zwei Hochzeiten und zwei Todesfälle",
-  "tag" : "gag481",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000679892820",
-  "url_spotify" : "https://open.spotify.com/episode/27vj3Ilu0g9qnymIBvDH3H"
-}, {
-  "title" : "Kein Klecks – die Erfindung des Kugelschreibers",
-  "tag" : "gag480",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000679071520",
-  "url_spotify" : "https://open.spotify.com/episode/6RTwYDJ0VMCrhgOFnbwCYs"
-}, {
-  "title" : "Über einen, der alles wusste – Athanasius Kircher",
-  "tag" : "gag479",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000678326005",
-  "url_spotify" : "https://open.spotify.com/episode/3IogvYQfAuVscKXoJT9zBo"
-}, {
-  "title" : "Das Königreich Ryukyu",
-  "tag" : "gag478",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000677459816",
-  "url_spotify" : "https://open.spotify.com/episode/63OM4XFRSrLasinlEsexUv"
-}, {
-  "title" : "Über Lochkarten, Anzüge und die Faszination Alhambra",
-  "tag" : "fgag18",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000677216728",
-  "url_spotify" : "https://open.spotify.com/episode/5fhF9FxtGFgVwA8jkEUcsy"
-}, {
-  "title" : "Kleine Geschichte des Artensterbens",
-  "tag" : "gag477",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000676694470",
-  "url_spotify" : "https://open.spotify.com/episode/4ie7NZ0HSV5rVlvUTSx6Zn"
-}, {
-  "title" : "Boabdil und das Ende Granadas",
-  "tag" : "gag476",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000675439410",
-  "url_spotify" : "https://open.spotify.com/episode/0PiZi2pnwMditk64bF3uVs"
-}, {
-  "title" : "Eine kleine Geschichte des Anzugs",
-  "tag" : "gag475",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000674876475",
-  "url_spotify" : "https://open.spotify.com/episode/77YC7cSXdrBTt1PnIsiGp7"
-}, {
-  "title" : "Eine kleine Geschichte des Zeitreisens",
-  "tag" : "gag474",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000673994096",
-  "url_spotify" : "https://open.spotify.com/episode/7wuaIy5fSLwQniquyHbPAV"
-}, {
-  "title" : "Die Erfindung der Lochkarte",
-  "tag" : "gag473",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000673214924",
-  "url_spotify" : "https://open.spotify.com/episode/3BmgIb6IC9ZwqJKRRVbogS"
-}, {
-  "title" : "Das Sommerspecial",
-  "tag" : "fgag17",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000672506772",
-  "url_spotify" : "https://open.spotify.com/episode/08UIt04hIspLwspdL9mFDw"
-}, {
-  "title" : "Die Antoninische Pest",
-  "tag" : "gag472",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000672137394",
-  "url_spotify" : "https://open.spotify.com/episode/73yjOYL2ZT184InxCNCTyf"
-}, {
-  "title" : "Karl XII. und das Ende des Schwedischen Reichs",
-  "tag" : "gag471",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000671433564",
-  "url_spotify" : "https://open.spotify.com/episode/2I7mi0Mnb4OXGnXuxmWdtE"
-}, {
-  "title" : "Alexis Soyer – Koch, Innovator und Philanthrop",
-  "tag" : "gag470",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000670526639",
-  "url_spotify" : "https://open.spotify.com/episode/2jedkVa6e6VJvigS6npo58"
-}, {
-  "title" : "Diebstahl der Mona Lisa",
-  "tag" : "gag469",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000669798113",
-  "url_spotify" : "https://open.spotify.com/episode/0HBpdQoFZEg3OXYJDpY50K"
-}, {
-  "title" : "Arabia Felix oder Die Dänisch Arabische Expedition",
-  "tag" : "gag468",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000669008245",
-  "url_spotify" : "https://open.spotify.com/episode/5paOofOmVYIhUJpa2EKOB6"
-}, {
-  "title" : "Das Leben der Lucrezia Borgia",
-  "tag" : "gag467",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000668218893",
-  "url_spotify" : "https://open.spotify.com/episode/2E1BeVDi0CK3CAzjBjFLqD"
-}, {
-  "title" : "A chat with Dr. Emma Southon on 21 women who shaped Roman History",
-  "tag" : "extra-AcwDESo2wwsRH",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000667777552",
-  "url_spotify" : "https://open.spotify.com/episode/1pmwhJGaVYCFYIBWA5XLVb"
-}, {
-  "title" : "Julia Felix und das Ende Pompejis",
-  "tag" : "gag466",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000666666516",
-  "url_spotify" : "https://open.spotify.com/episode/7qPsODMyQhjTM12MfTvXU6"
-}, {
-  "title" : "Wie Aluminium entdeckt wurde",
-  "tag" : "gag465",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000666044957",
-  "url_spotify" : "https://open.spotify.com/episode/5yfmrAO9HipHJ3KhgY87Qv"
-}, {
-  "title" : "Die Entstehung des Central Parks",
-  "tag" : "gag464",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000664810729",
-  "url_spotify" : "https://open.spotify.com/episode/1XVg8frLjCARbokNY2vGiW"
-}, {
-  "title" : "Die Erfindung der Glühlampe",
-  "tag" : "gag463",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000664461324",
-  "url_spotify" : "https://open.spotify.com/episode/7ELvynYSs0Pr1945V6jxLC"
-}, {
-  "title" : "Die Schlacht an den Thermopylen oder Das erste letzte Gefecht der Geschichte",
-  "tag" : "gag462",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000663791788",
-  "url_spotify" : "https://open.spotify.com/episode/3bdWMbEpjWS1NcSmv4NAmY"
-}, {
-  "title" : "Das längste Autorennen der Welt",
-  "tag" : "gag461",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000663130550",
-  "url_spotify" : "https://open.spotify.com/episode/33cKv4aLWnfnRY3D79s6eK"
-}, {
-  "title" : "Lorenzo Da Ponte oder Wie ein Librettist entsteht",
-  "tag" : "gag460",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000662404324",
-  "url_spotify" : "https://open.spotify.com/episode/1n9dO3XyFPSjyFuYPACZST"
-}, {
-  "title" : "Eine Kaiserin für Brasilien",
-  "tag" : "gag459",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000661700355",
-  "url_spotify" : "https://open.spotify.com/episode/2IXlpgFsBC8A8YMqy7gNvl"
-}, {
-  "title" : "Über Toilettengang im All, die Métis-Fiddle und Belletristik zu berühmten Hirnen",
-  "tag" : "fgag16",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000661326636",
-  "url_spotify" : "https://open.spotify.com/episode/0PLFl9jf7mqDmfRTJ0KbNQ"
-}, {
-  "title" : "Wie wir die Nacht zum Tag machten",
-  "tag" : "gag458",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000660832286",
-  "url_spotify" : "https://open.spotify.com/episode/0UEAaIdc6S3nVjmCgppnWR"
-}, {
-  "title" : "Die Ermordung des Burgunderherzogs",
-  "tag" : "gag457",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000660164683",
-  "url_spotify" : "https://open.spotify.com/episode/1FupzpcOMhjnB8sk7OeSa2"
-}, {
-  "title" : "Bierkriege – Tatort Geschichte Crossover",
-  "tag" : "gag456",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000659437681",
-  "url_spotify" : "https://open.spotify.com/episode/6mSXCvsrhPsLLKBuHp0GeC"
-}, {
-  "title" : "Das Unternehmen Pastorius",
-  "tag" : "gag455",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000658601659",
-  "url_spotify" : "https://open.spotify.com/episode/7ykXCRHoRDBhkEBwkMSpXg"
-}, {
-  "title" : "Geniale Gehirne",
-  "tag" : "gag454",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000657651210",
-  "url_spotify" : "https://open.spotify.com/episode/670NGn5lHi6QDiKerasnWG"
-}, {
-  "title" : "Pemmikan und der Pelzhandel in Nordamerika",
-  "tag" : "gag453",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000657038476",
-  "url_spotify" : "https://open.spotify.com/episode/2XoZum7eNrcfLCJEqsIVZE"
-}, {
-  "title" : "Der GAG-Effekt",
-  "tag" : "fgag15",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000656758667",
-  "url_spotify" : "https://open.spotify.com/episode/3v7i1n24EPvDgqcupmXCEM"
-}, {
-  "title" : "Der erste Mensch im All",
-  "tag" : "gag452",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000656366515",
-  "url_spotify" : "https://open.spotify.com/episode/2b15qaraQH7Eq8UK9K24AU"
-}, {
-  "title" : "Eine kleine Geschichte der verlorenen Bücher",
-  "tag" : "gag451",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000655558002",
-  "url_spotify" : "https://open.spotify.com/episode/0QkfKByAMNwlkkWDslYBsf"
-}, {
-  "title" : "Tudor und der Eishandel",
-  "tag" : "gag450",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000654795741",
-  "url_spotify" : "https://open.spotify.com/episode/1ov1eG8on20AVCq6eOyfKA"
-}, {
-  "title" : "Die Wiederentdeckung der Moriori",
-  "tag" : "gag449",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000653914480",
-  "url_spotify" : "https://open.spotify.com/episode/4Wmtb61eQ1StjNXTjiZ5Fi"
-}, {
-  "title" : "Die Phenol-Verschwörung",
-  "tag" : "gag448",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000653384492",
-  "url_spotify" : "https://open.spotify.com/episode/7MqpioF3kBryzQhshttK7B"
-}, {
-  "title" : "Christina, Hans und Heinrich oder Wie ein Gemälde entsteht",
-  "tag" : "gag447",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000652601553",
-  "url_spotify" : "https://open.spotify.com/episode/3AqXpXernJq9n7BQNznFcn"
-}, {
-  "title" : "Ein Duft aus Köln",
-  "tag" : "gag446",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000651869680",
-  "url_spotify" : "https://open.spotify.com/episode/75hlZvWmz2oIMNnFPZRAqn"
-}, {
-  "title" : "Über Knopflöcher, Propaganda im frühen Perserreich und zu hohe Fahrräder",
-  "tag" : "fgag14",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000651666293",
-  "url_spotify" : "https://open.spotify.com/episode/5WDKeG9fD0sreNbDGUafFL"
-}, {
-  "title" : "Alexandra David-Néel",
-  "tag" : "gag445",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000651207304",
-  "url_spotify" : "https://open.spotify.com/episode/18cEudoxSb717DoA1VFkZ1"
-}, {
-  "title" : "Die Erfindung von Heroin und Aspirin",
-  "tag" : "gag444",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000650484872",
-  "url_spotify" : "https://open.spotify.com/episode/1equTrRAwUHIrssXg1iLRn"
-}, {
-  "title" : "J.S. Bach oder Wie sich ein Komponist den Lebensunterhalt verdient",
-  "tag" : "gag443",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000649694604",
-  "url_spotify" : "https://open.spotify.com/episode/5XHadbN1UnL1Zp2ipDsk1o"
-}, {
-  "title" : "Eine kurze Geschichte des Fahrrads",
-  "tag" : "gag442",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000648924288",
-  "url_spotify" : "https://open.spotify.com/episode/7xn0EQD9rnalFiFTSvpjLv"
-}, {
-  "title" : "Jemima Nicholas und die Schlacht von Fishguard",
-  "tag" : "gag441",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000648088616",
-  "url_spotify" : "https://open.spotify.com/episode/3UqDAZHrNthDojZSJS07gd"
-}, {
-  "title" : "Eine Giraffe für den König",
-  "tag" : "gag440",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000647214270",
-  "url_spotify" : "https://open.spotify.com/episode/1ihRKSFRdS5grkF9Vq6LoH"
-}, {
-  "title" : "Kyros II. und die Entstehung eines Mythos",
-  "tag" : "gag439",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000646053195",
-  "url_spotify" : "https://open.spotify.com/episode/07K1lm94M1ua9FHhPNdhDA"
-}, {
-  "title" : "Die Pinkerton-Detektei",
-  "tag" : "gag438",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000645186516",
-  "url_spotify" : "https://open.spotify.com/episode/0HAbZ6vA0jQaNahnK9k8SV"
-}, {
-  "title" : "Die holprige Karriere des Reißverschlusses",
-  "tag" : "gag437",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000644264926",
-  "url_spotify" : "https://open.spotify.com/episode/5JTAR5GPWF0InVhPElP1nO"
-}, {
-  "title" : "Post aus der Antarktis, Korrekturen zum Deutsch-Französischen Krieg und vieles mehr",
-  "tag" : "fgag13",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000644055598",
-  "url_spotify" : "https://open.spotify.com/episode/4wFxsrC2hcsWVeos9RJ2oY"
-}, {
-  "title" : "Die Jagd nach El­do­ra­do",
-  "tag" : "gag436",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000643573981",
-  "url_spotify" : "https://open.spotify.com/episode/13NjRiee0mU3uLTQULl6G5"
-}, {
-  "title" : "Die Schlacht bei Carrhae",
-  "tag" : "gag435",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000642640291",
-  "url_spotify" : "https://open.spotify.com/episode/494YGqkk4Wq4s6TGG4ZAwS"
-}, {
-  "title" : "Ein willkommener Mörder",
-  "tag" : "gag434",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000641895496",
-  "url_spotify" : "https://open.spotify.com/episode/4jvurbgxZhc226qfIGuR0W"
-}, {
-  "title" : "Der Schinderhannes",
-  "tag" : "gag433",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000641037112",
-  "url_spotify" : "https://open.spotify.com/episode/76fsJ0DFVQl8oWhkM5XlvD"
-}, {
-  "title" : "Ein bitteres Heilmittel",
-  "tag" : "gag432",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000640365150",
-  "url_spotify" : "https://open.spotify.com/episode/0BNvvaAhtn5z9ExySztWa1"
-}, {
-  "tag" : "gag431",
-  "title" : "Auguste Escoffier, Kaiser der Köche",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000639733434",
-  "url_spotify" : "https://open.spotify.com/episode/6yL6CF3JX4GS9NhKbYtvwB"
-}, {
-  "tag" : "fgag12",
-  "title" : "Viel Post, viel Feedback, viel Freude",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000639547729",
-  "url_spotify" : "https://open.spotify.com/episode/1ftkfPlFJn6KpQwATv90Vm"
-}, {
-  "tag" : "gag430",
-  "title" : "Gefangene und Königin – Johanna I. von Kastilien",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000639093010",
-  "url_spotify" : "https://open.spotify.com/episode/0WqzIuRDvW6heOYa1FpdDX"
-}, {
-  "tag" : "gag429",
-  "title" : "Der Eimerkrieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000638321858",
-  "url_spotify" : "https://open.spotify.com/episode/27ZzzrEKXRv1EzuPsMtayK"
-}, {
-  "tag" : "gag428",
-  "title" : "Der Fälscher Konstantinos Simonides",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000637567530",
-  "url_spotify" : "https://open.spotify.com/episode/7hmH1wzl0iNDo9XNdSg9lu"
-}, {
-  "tag" : "gag427",
-  "title" : "Das große Erdbeben von Lissabon",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000636791860",
-  "url_spotify" : "https://open.spotify.com/episode/3Xqud86b5jFoueOM2ztKZU"
-}, {
-  "tag" : "gag426",
-  "title" : "Die erste Regisseurin – Alice Guy",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000635649882",
-  "url_spotify" : "https://open.spotify.com/episode/7wSpYESpS2ydF9ck15j76c"
-}, {
-  "tag" : "gag425",
-  "title" : "Shampooing und die vier Leben des Dean Mahomet",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000634646551",
-  "url_spotify" : "https://open.spotify.com/episode/4wwdYl0GLqnbmhOJuGuWlM"
-}, {
-  "tag" : "gag424",
-  "title" : "Die Erfindung der Briefmarke",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000634052837",
-  "url_spotify" : "https://open.spotify.com/episode/0mujyQEJhgk9a7AzufD3dK"
-}, {
-  "tag" : "gag423",
-  "title" : "Der Sohn Gottes Hong Xiuquan und sein Aufstand gegen das imperiale China",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000633140328",
-  "url_spotify" : "https://open.spotify.com/episode/0kxC5sgRVodCu9ykwPOZzT"
-}, {
-  "tag" : "gag422",
-  "title" : "Eine kleine Geschichte der Parapsychologie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000632463512",
-  "url_spotify" : "https://open.spotify.com/episode/5pClVdyRPvDh0lF2CJf66s"
-}, {
-  "tag" : "gag421",
-  "title" : "Playfair und die Erfindung des Balkendiagramms",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000631577194",
-  "url_spotify" : "https://open.spotify.com/episode/7Hif8qSW7HBSdqx31OuXmF"
-}, {
-  "tag" : "gag420",
-  "title" : "Harry Anslinger und der erste \"War on Drugs\"",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000630850131",
-  "url_spotify" : "https://open.spotify.com/episode/7poDiZofCFHLUd3sYGMlqG"
-}, {
-  "tag" : "gag419",
-  "title" : "Therese von Thurn und Taxis und das Ende der Reichspost",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000630091149",
-  "url_spotify" : "https://open.spotify.com/episode/52HKUjBXYIlhiHb49fguP4"
-}, {
-  "tag" : "gag418",
-  "title" : "Das älteste Gewürz der Welt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000629174492",
-  "url_spotify" : "https://open.spotify.com/episode/0h9zUGpJS2hMHBCAlnlc7u"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000628917483",
-  "url_spotify" : "https://open.spotify.com/episode/0KvgeVhE2e2oIspY5rA7ib",
-  "title" : "Samuel Pepys, Lady Six Sky und Daniel singt",
-  "tag" : "fgag11"
-}, {
-  "tag" : "gag417",
-  "title" : "Auf der Suche nach den Quellen des Nils",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000628503911",
-  "url_spotify" : "https://open.spotify.com/episode/323apOXR2RCITt7l5KB4Ru"
-}, {
-  "tag" : "gag416",
-  "title" : "Wie das Münzgeld entstand",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000627490415",
-  "url_spotify" : "https://open.spotify.com/episode/1Sw43hTkJdXKsfi6Aiye9Q"
-}, {
-  "tag" : "gag415",
-  "title" : "Polarpionier Fridtjof Nansen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000626721063",
-  "url_spotify" : "https://open.spotify.com/episode/3DUJ1LwVcgIhpkkY7IrFLN"
-}, {
-  "tag" : "gag414",
-  "title" : "Ibn Fadlān und die Reise zur Wolga",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000626087460",
-  "url_spotify" : "https://open.spotify.com/episode/4j7CKhEsB1FDQOR1p3NIyj"
-}, {
-  "tag" : "gag413",
-  "title" : "Paracelsus – Arzt und Alchemist",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000625306816",
-  "url_spotify" : "https://open.spotify.com/episode/7zaLPssTvryNMJA7WEGekZ"
-}, {
-  "tag" : "gag412",
-  "title" : "Samuel Pepys und das außergewöhnlichste Tagebuch des 17. Jahrhunderts",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000624291170",
-  "url_spotify" : "https://open.spotify.com/episode/4eEHaoAWheBQUsqDt3bxoY"
-}, {
-  "tag" : "gag411",
-  "title" : "Der Untergang der Thomas W. Lawson",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000623846225",
-  "url_spotify" : "https://open.spotify.com/episode/2pVvKDIFV3sWW2h33dxraG"
-}, {
-  "tag" : "gag410",
-  "title" : "Lady Six Sky und eine kurze Geschichte der Maya",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000623048236",
-  "url_spotify" : "https://open.spotify.com/episode/7EluT4JIKGxDGV92Wmp1iO"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000622805862",
-  "url_spotify" : "https://open.spotify.com/episode/3oikpzqnBDECLO9fEDcSJ5",
-  "title" : "Die Rückkehr, eine Ankündigung und ein Interview",
-  "tag" : "fgag10"
-}, {
-  "tag" : "gag409",
-  "title" : "Pferdefotos und ein Mord",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000622298642",
-  "url_spotify" : "https://open.spotify.com/episode/6BJsa1KOPyNeO3jtDVQDLe"
-}, {
-  "tag" : "gag408",
-  "title" : "Das kurze und tragische Leben des Évariste Galois",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000621411576",
-  "url_spotify" : "https://open.spotify.com/episode/1Naq643qaXfN6Z5inbxbde"
-}, {
-  "tag" : "gag407",
-  "title" : "Das katastrophale Ende einer Kolonie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000620822300",
-  "url_spotify" : "https://open.spotify.com/episode/3vLIKH763L6htdAKXGGiA7"
-}, {
-  "tag" : "gag406",
-  "title" : "Die SMS Wolf und die Piraten des Kaisers",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000619254302",
-  "url_spotify" : "https://open.spotify.com/episode/4usCnESJcPoug0uPjcclyS"
-}, {
-  "tag" : "gag405",
-  "title" : "Bonifatius, Apostel der Deutschen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000618475480",
-  "url_spotify" : "https://open.spotify.com/episode/3ycfXc6Ik8tA7SEqjLhnQr"
-}, {
-  "tag" : "gag404",
-  "title" : "Not Found",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000617699118",
-  "url_spotify" : "https://open.spotify.com/episode/3Ho2Y9H9oAOcMihzd5ltNf"
-}, {
-  "tag" : "gag403",
-  "title" : "Maxentius – Der letzte Kaiser in Rom",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000616816141",
-  "url_spotify" : "https://open.spotify.com/episode/6l6YLiTugae4Xfb8uvpi5Y"
-}, {
-  "tag" : "gag402",
-  "title" : "Die Vegetarian Society und die Begründung des modernen Vegetarismus",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000615868154",
-  "url_spotify" : "https://open.spotify.com/episode/0h3nKBXgksyErQ0gG1HAR3"
-}, {
-  "tag" : "gag401",
-  "title" : "Amerika und die Weltkarte von Waldseemüller",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000615045038",
-  "url_spotify" : "https://open.spotify.com/episode/7pB4E5GbILiABYRx0xi0vQ"
-}, {
-  "tag" : "gag400",
-  "title" : "GAG X Anno Mundi – Anicia Juliana",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000614272530",
-  "url_spotify" : "https://open.spotify.com/episode/33ZZ4TvWCe1fmFBEbHOwBV"
-}, {
-  "tag" : "gag399",
-  "title" : "John Brown und sein gescheiterter Sklavenaufstand",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000613205069",
-  "url_spotify" : "https://open.spotify.com/episode/071RVIzXd5Y9PXDrLV4KkU"
-}, {
-  "tag" : "gag398",
-  "title" : "Der Goldene Brief",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000612302102",
-  "url_spotify" : "https://open.spotify.com/episode/3ESDt2JMHku1Bh7J1OZmUI"
-}, {
-  "tag" : "gag397",
-  "title" : "Hy Brasil",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000611281335",
-  "url_spotify" : "https://open.spotify.com/episode/6TIY43fiPvadsBkB91rLIz"
-}, {
-  "tag" : "gag396",
-  "title" : "Helene Kottannerin und der Raub der Stephanskrone",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000610561792",
-  "url_spotify" : "https://open.spotify.com/episode/71tzGjiFFzsSlm0x60vIYs"
-}, {
-  "tag" : "gag395",
-  "title" : "Barbe-Nicole Ponsardin und die Begründung eines Champagnerimperiums",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000609487014",
-  "url_spotify" : "https://open.spotify.com/episode/7EeFvRdpjZtCmvQCx9aACQ"
-}, {
-  "tag" : "gag394",
-  "title" : "Die Verurteilung von Sacco und Vanzetti",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000608401258",
-  "url_spotify" : "https://open.spotify.com/episode/1q9a6eULL6QR9LIzyFMqKg"
-}, {
-  "tag" : "gag393",
-  "title" : "Die Schlacht von Zama",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000607485890",
-  "url_spotify" : "https://open.spotify.com/episode/60aAlOr3F4KaCYJ5pBYxh2"
-}, {
-  "tag" : "gag392",
-  "title" : "Phosphor und der Streik der Streichholzarbeiterinnen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000606284100",
-  "url_spotify" : "https://open.spotify.com/episode/7lwYowFINltY7TGhzFCmzF"
-}, {
-  "tag" : "gag391",
-  "title" : "Celia Cooney, die Banditin mit der Kurzhaarfrisur",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000605061109",
-  "url_spotify" : "https://open.spotify.com/episode/7j1tlucLVjbJqgnJDN1oyf"
-}, {
-  "tag" : "gag390",
-  "title" : "Kleopatra Selene und das Ende der Römischen Republik",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000604132418",
-  "url_spotify" : "https://open.spotify.com/episode/5iMNLFjRiIMEkFWWpOoTqd"
-}, {
-  "tag" : "gag389",
-  "title" : "Spieglein, Spieglein an der Wand",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000603260848",
-  "url_spotify" : "https://open.spotify.com/episode/5fL7hb3Li7zSVtGsExTXaM"
-}, {
-  "tag" : "gag388",
-  "title" : "Marie Tussaud und die Wachsfiguren",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000602099169",
-  "url_spotify" : "https://open.spotify.com/episode/599lEEoWGsnLWTGMgM2HBT"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000601576673",
-  "url_spotify" : "https://open.spotify.com/episode/1tVvrum0BdEWRWYi0liruw",
-  "title" : "Theodor von Neuhoff, Verwirrungen im metrischen System und warum Bletchley Park den Krieg verkürzte",
-  "tag" : "fgag9"
-}, {
-  "tag" : "gag387",
-  "title" : "Nurhaci und die Entstehung der Mandschu",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000600930095",
-  "url_spotify" : "https://open.spotify.com/episode/3DRH31vYzfdsa6hvDSRzqu"
-}, {
-  "tag" : "gag386",
-  "title" : "Der Wettlauf zum Nordpol",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000599616659",
-  "url_spotify" : "https://open.spotify.com/episode/4fgXxqWtqe5liPo0nozwbN"
-}, {
-  "tag" : "gag385",
-  "title" : "Delmonico's und der erste Starkoch der USA",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000598487977",
-  "url_spotify" : "https://open.spotify.com/episode/0o6gBxeqpYWuNXenT8g8jA"
-}, {
-  "tag" : "gag384",
-  "title" : "Flaschenpost und die Erforschung der Ozeane",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000597409855",
-  "url_spotify" : "https://open.spotify.com/episode/6Ow1qsEuVVtww7znhARD5A"
-}, {
-  "tag" : "gag383",
-  "title" : "Bletchley Park",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000596383457",
-  "url_spotify" : "https://open.spotify.com/episode/6MqxA6iJO5suy0a6EhfdYz"
-}, {
-  "tag" : "gag382",
-  "title" : "Der erste Film",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000595069993",
-  "url_spotify" : "https://open.spotify.com/episode/6EBHq2oNjnX9EIM4wX4vh7"
-}, {
-  "tag" : "gag381",
-  "title" : "Mau Piailug und die Besiedelung des Pazifiks",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000593499065",
-  "url_spotify" : "https://open.spotify.com/episode/1yKqQS2C7a1t7ZdyBnSNLn"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000592992416",
-  "url_spotify" : "https://open.spotify.com/episode/0x56KC9w9Ea5qKdOEZeCHK",
-  "title" : "In der Stratosphäre",
-  "tag" : "fgag8"
-}, {
-  "tag" : "gag380",
-  "title" : "Das Maß aller Dinge",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000592199826",
-  "url_spotify" : "https://open.spotify.com/episode/3NqmohnX5qZQAAx9lXfpQA"
-}, {
-  "tag" : "gag379",
-  "title" : "Theodor von Neuhoff - König von Korsika",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000591396639",
-  "url_spotify" : "https://open.spotify.com/episode/07oRBPofKWIgZypLIzd210"
-}, {
-  "tag" : "gag378",
-  "title" : "Ein langer Marsch durch Feindesland",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000590784721",
-  "url_spotify" : "https://open.spotify.com/episode/3njA5iMrsvaLWojTSfRHZq"
-}, {
-  "tag" : "gag377",
-  "title" : "Aufstieg und Fall des Templerordens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000590045562",
-  "url_spotify" : "https://open.spotify.com/episode/645B9arZRseafJ2uHr6ieQ"
-}, {
-  "tag" : "gag376",
-  "title" : "Nagelmackers und der Orient-Express",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000589118983",
-  "url_spotify" : "https://open.spotify.com/episode/2YA333ta4eVHBuoV2RhRTX"
-}, {
-  "tag" : "gag375",
-  "title" : "Sofia Kowalewskaja, \"Königin der Wissenschaft\"",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000587914310",
-  "url_spotify" : "https://open.spotify.com/episode/4K5f7FA5o1dM5pL1ToGQDY"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000587604551",
-  "url_spotify" : "https://open.spotify.com/episode/1CjwGUWFlHcTpcK78CX9dP",
-  "title" : "Bibi & Tina, Casinos in Macau und noch mehr Schiffe in Maisfeldern",
-  "tag" : "fgag7"
-}, {
-  "tag" : "gag374",
-  "title" : "Ludwik Fleck und das Fleckfieber",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000587113881",
-  "url_spotify" : "https://open.spotify.com/episode/6jG9f64ULNBbCttt3vooxu"
-}, {
-  "tag" : "gag373",
-  "title" : "Morocco und der Kluge Hans",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000586141813",
-  "url_spotify" : "https://open.spotify.com/episode/7yr8I56gD3roFmTk2JivOv"
-}, {
-  "tag" : "gag372",
-  "title" : "Wie das Roulette eine Null verlor",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000585556096",
-  "url_spotify" : "https://open.spotify.com/episode/3BpNw8EOhIPR2Am5OLK95V"
-}, {
-  "tag" : "gag371",
-  "title" : "Galla Placidia",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000584653958",
-  "url_spotify" : "https://open.spotify.com/episode/1dWrhLoDZyzDwOSv2C5zFS"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000584353460",
-  "url_spotify" : "https://open.spotify.com/episode/1PoqBwSRdgJ1C29YCYVxNi",
-  "title" : "Egostory, Schwesterschiff und ein Freispruch für die Gletscher",
-  "tag" : "fgag6"
-}, {
-  "tag" : "gag370",
-  "title" : "Der Kodex des Archimedes",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000583879315",
-  "url_spotify" : "https://open.spotify.com/episode/74WbADI4ZVPlja4bqQqhsf"
-}, {
-  "tag" : "gag369",
-  "title" : "Der Struwwelpeter",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000583127588",
-  "url_spotify" : "https://open.spotify.com/episode/2C7Tzsvke6wOhDsoRlm5cY"
-}, {
-  "tag" : "gag368",
-  "title" : "Wie das Jod ins Salz kam",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000582320849",
-  "url_spotify" : "https://open.spotify.com/episode/0BfEJ7iEOyEDbpBYTnRbXz"
-}, {
-  "tag" : "gag367",
-  "title" : "Untergang und Comeback der VASA",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000581644522",
-  "url_spotify" : "https://open.spotify.com/episode/5BOJlSWrYotsqydJb19WuV"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000581286573",
-  "url_spotify" : "https://open.spotify.com/episode/75TQVCDCc9LewnYesM0rqZ",
-  "title" : "Duke in Paris, Jazzualdo und die Ghost Army",
-  "tag" : "fgag5"
-}, {
-  "tag" : "gag366",
-  "title" : "Das Attentat von Anagni",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000580832830",
-  "url_spotify" : "https://open.spotify.com/episode/4RbsOV1N2fNqhRyX2CpYNx"
-}, {
-  "tag" : "gag365",
-  "title" : "The Ghost Army",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000580158090",
-  "url_spotify" : "https://open.spotify.com/episode/3nYr2NgEd8tw3s8OdTA1QB"
-}, {
-  "tag" : "gag364",
-  "title" : "Mord und Madrigale – Carlo Gesualdo",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000579321767",
-  "url_spotify" : "https://open.spotify.com/episode/5Z1w9KQ7ZwS1jLr60bbArs"
-}, {
-  "tag" : "gag363",
-  "title" : "Duke Kahanamoku",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000578556859",
-  "url_spotify" : "https://open.spotify.com/episode/1jrwqCzBwA7UVL39yVB44U"
-}, {
-  "tag" : "gag362",
-  "title" : "Bayerns letzte Kurfürstin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000577840766",
-  "url_spotify" : "https://open.spotify.com/episode/23eYk7vmb7qd1mroHb393K"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000577536066",
-  "url_spotify" : "https://open.spotify.com/episode/3bmox23uiYQVag3MzIqM7g",
-  "title" : "Reinhard und das Reis-Telefon",
-  "tag" : "fgag4"
-}, {
-  "tag" : "gag361",
-  "title" : "Gustave Trouvé - der vergessene Erfinder",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000577076144",
-  "url_spotify" : "https://open.spotify.com/episode/6ypMcsbkeyts9iVkH0odTy"
-}, {
-  "tag" : "gag360",
-  "title" : "Unglück am Matterhorn",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000576231061",
-  "url_spotify" : "https://open.spotify.com/episode/1rvwr7vymqXzuVSVDMi8us"
-}, {
-  "tag" : "gag359",
-  "title" : "Eine kleine Geschichte des Schachspiels",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000575522961",
-  "url_spotify" : "https://open.spotify.com/episode/0lhKCVm07qi4sMUz1OWfGd"
-}, {
-  "tag" : "gag358",
-  "title" : "Philipp Reis und die Erfindung des Telefons",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000574812482",
-  "url_spotify" : "https://open.spotify.com/episode/0DPCPrbqxUmW8pZDRrJZRo"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000574516319",
-  "url_spotify" : "https://open.spotify.com/episode/0ygbw6NRZ4VVtmUKhNMzwx",
-  "title" : "Erwin Kreuz - ein Update",
-  "tag" : "fgag3"
-}, {
-  "tag" : "gag357",
-  "title" : "Mary Kingsley",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000571226092",
-  "url_spotify" : "https://open.spotify.com/episode/5JgjPBBVJlj4joOrr9Nbi0"
-}, {
-  "tag" : "gag356",
-  "title" : "Das DeLorean-Drama",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000570513486",
-  "url_spotify" : "https://open.spotify.com/episode/3dVoTRNq5ZZYd70J2WAyWT"
-}, {
-  "tag" : "gag355",
-  "title" : "Der Englische Schweiß",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000569655974",
-  "url_spotify" : "https://open.spotify.com/episode/1LHUGifx9iOgwve439gwtd"
-}, {
-  "tag" : "gag354",
-  "title" : "Die Halsbandaffäre",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000568931104",
-  "url_spotify" : "https://open.spotify.com/episode/0kLRn01YrbTcHolzfoJ2vW"
-}, {
-  "tag" : "gag353",
-  "title" : "Wallada",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000567988912",
-  "url_spotify" : "https://open.spotify.com/episode/6lW3iEaZeUNXshmmD0tsnI"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000567587985",
-  "url_spotify" : "https://open.spotify.com/episode/5DGvoxzoqX6bANdSEEzetJ",
-  "title" : "Mord auf Ex",
-  "tag" : "fgag2"
-}, {
-  "tag" : "gag352",
-  "title" : "Wallace und das Rennen um die Evolutionstheorie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000567310021",
-  "url_spotify" : "https://open.spotify.com/episode/3r1kjFzJlkeMDWoBo6wNwr"
-}, {
-  "tag" : "gag351",
-  "title" : "Die Erfindung des Saxophons - Aufstieg und Fall des Adolphe Sax",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000566381434",
-  "url_spotify" : "https://open.spotify.com/episode/6bOmMelXYJzAoT4CxPIqgQ"
-}, {
-  "tag" : "gag350",
-  "title" : "Der Bauernkrieg und die Revolution von 1525",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000565555245",
-  "url_spotify" : "https://open.spotify.com/episode/4o6bNtUiYX0qXRqa94rk0g"
-}, {
-  "tag" : "gag349",
-  "title" : "Konstantin Phaulkon im Königreich Ayutthaya",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000564430382",
-  "url_spotify" : "https://open.spotify.com/episode/1pBUaprompoulevMrhO7PL"
-}, {
-  "tag" : "gag348",
-  "title" : "Der Anschlag auf die Mosel",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000563378005",
-  "url_spotify" : "https://open.spotify.com/episode/2O84khezHm2bAEIE5a5Rft"
-}, {
-  "tag" : "gag347",
-  "title" : "Adrianopel 378",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000561883145",
-  "url_spotify" : "https://open.spotify.com/episode/3XMHOK1ecTQm02q6uz7poI"
-}, {
-  "tag" : "gag346",
-  "title" : "Die längste Hängebrücke der Welt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000560365723",
-  "url_spotify" : "https://open.spotify.com/episode/5Miu0Yww4t7G5SeeRG5mKD"
-}, {
-  "tag" : "gag345",
-  "title" : "Suffrajitsu",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000559475571",
-  "url_spotify" : "https://open.spotify.com/episode/5yZsoqYsVe0YHe7Flaizcb"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000559087695",
-  "url_spotify" : "https://open.spotify.com/episode/5WDO2wTWbl3c3vODs9v4Dm",
-  "title" : "Atlantropa",
-  "tag" : "fgag1"
-}, {
-  "tag" : "gag344",
-  "title" : "Der Artischockenkrieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000558836719",
-  "url_spotify" : "https://open.spotify.com/episode/2XVlQ0WMRRqdUc6RDZfuT0"
-}, {
-  "tag" : "gag343",
-  "title" : "Phoebus und die geplante Obsoleszenz",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000558127252",
-  "url_spotify" : "https://open.spotify.com/episode/30b1HpKkZwfOQbY4stTK8C"
-}, {
-  "tag" : "gag342",
-  "title" : "Das Stockholmer Blutbad",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000557449800",
-  "url_spotify" : "https://open.spotify.com/episode/72fCjH4KYcZHwBH0YBySKE"
-}, {
-  "tag" : "gag341",
-  "title" : "Der Exorzismus der Marthe Brossier",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000556392215",
-  "url_spotify" : "https://open.spotify.com/episode/45fhh5sWBQ0iayg7HnNgBx"
-}, {
-  "tag" : "gag340",
-  "title" : "Tauben, die Raketen steuern und Kybernetik",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000555683312",
-  "url_spotify" : "https://open.spotify.com/episode/1otGUTMUFtt7P1LeXKdV82"
-}, {
-  "tag" : "gag339",
-  "title" : "Der Vocoder",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000554957063",
-  "url_spotify" : "https://open.spotify.com/episode/7M4gHT16LFGYdRODJryKu6"
-}, {
-  "tag" : "gag338",
-  "title" : "Eine neue Gesellschaft – Frühsozialist Robert Owen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000554183534",
-  "url_spotify" : "https://open.spotify.com/episode/0UtDiqbD3Hd98lkI18sCjK"
-}, {
-  "tag" : "gag337",
-  "title" : "Über Hummer, Kaviar und wie das Loch in den Donut kam",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000553414266",
-  "url_spotify" : "https://open.spotify.com/episode/7tK9tHNzF6GHefMaYAokih"
-}, {
-  "tag" : "gag336",
-  "title" : "George Smith und die Entdeckung des Gilgamesch-Epos",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000552671470",
-  "url_spotify" : "https://open.spotify.com/episode/6Zch4g9bB5tIZrstCCpZ4J"
-}, {
-  "tag" : "gag335",
-  "title" : "Aqua Tofana und die Giftmischerinnen des 17. Jahrhunderts",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000551977326",
-  "url_spotify" : "https://open.spotify.com/episode/61wkJd6BhqNKKPGfSxSgFK"
-}, {
-  "tag" : "gag334",
-  "title" : "Rachel Carson und der stumme Frühling",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000551255899",
-  "url_spotify" : "https://open.spotify.com/episode/6KoUzv5BLr96WIWSH4Jtoi"
-}, {
-  "tag" : "gag333",
-  "title" : "Alexandria",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000550532186",
-  "url_spotify" : "https://open.spotify.com/episode/2p9RddGLpyneh9qVPikXhN"
-}, {
-  "tag" : "gag332",
-  "title" : "Wie Gregor MacGregor ein Land verkaufte, das es gar nicht gab",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000549752662",
-  "url_spotify" : "https://open.spotify.com/episode/0vogVo5htsZLW0ZjBbz8SV"
-}, {
-  "tag" : "gag331",
-  "title" : "Wie Tetris die Welt eroberte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000549035712",
-  "url_spotify" : "https://open.spotify.com/episode/2LeI7kIpznuvLRti6sN5A6"
-}, {
-  "tag" : "gag330",
-  "title" : "Zum Tode verurteilt – Catharina Linck alias Anastasius Lagrantinus Rosenstengel",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000548325330",
-  "url_spotify" : "https://open.spotify.com/episode/1dYdoOM6qBwRw04SobOp3v"
-}, {
-  "tag" : "gag329",
-  "title" : "Wie der Wolf zum Hund wurde",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000547641555",
-  "url_spotify" : "https://open.spotify.com/episode/0Cuu1cTBT5YB891HDUl85f"
-}, {
-  "tag" : "gag328",
-  "title" : "P. T. Barnum und die größte Show der Welt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000546982788",
-  "url_spotify" : "https://open.spotify.com/episode/3E6nheQGDHrxuxYaTvQJjX"
-}, {
-  "tag" : "gag327",
-  "title" : "Das große Geburtenrennen von Toronto",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000546403125",
-  "url_spotify" : "https://open.spotify.com/episode/4pqV9aT8KfBFBujVsmWKyr"
-}, {
-  "tag" : "gag326",
-  "title" : "Ausgestorbene und außergewöhnliche Berufe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000545751330",
-  "url_spotify" : "https://open.spotify.com/episode/6rVekPkZANjxP7O3t1QRhU"
-}, {
-  "tag" : "gag325",
-  "title" : "Der Große Smog von 1952",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000545025399",
-  "url_spotify" : "https://open.spotify.com/episode/7s5EMgl5c6Tlv1Ot845OmW"
-}, {
-  "tag" : "gag324",
-  "title" : "Mit dem Ballon zum Nordpol – Andrées Polarexpedition von 1897",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000544297879",
-  "url_spotify" : "https://open.spotify.com/episode/1kMtaLBD0qCiATkysn33IW"
-}, {
-  "tag" : "gag323",
-  "title" : "Die Republik Ezo und das Ende des Shogunats",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000543595979",
-  "url_spotify" : "https://open.spotify.com/episode/55INRbxYgsGoEpk5en4WzW"
-}, {
-  "tag" : "gag322",
-  "title" : "Portugal und der Seeweg nach Indien",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000542926944",
-  "url_spotify" : "https://open.spotify.com/episode/7i4aTThxApd9rRBMayNGC6"
-}, {
-  "tag" : "gag321",
-  "title" : "Aufstieg und möglicher Fall der Banane",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000542189759",
-  "url_spotify" : "https://open.spotify.com/episode/433Ta0iBi14pS9AtS3xDf5"
-}, {
-  "tag" : "gag320",
-  "title" : "In 72 Tagen um die Welt – Journalistin Nellie Bly",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000541320322",
-  "url_spotify" : "https://open.spotify.com/episode/10c1VBb1PrpWnUvu0jyYtt"
-}, {
-  "tag" : "gag319",
-  "title" : "Ashoka der Große",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000540601614",
-  "url_spotify" : "https://open.spotify.com/episode/2C9oVi4J7yNf45092jZhz2"
-}, {
-  "tag" : "gag318",
-  "title" : "Der Nuklearunfall von Goiânia",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000539861680",
-  "url_spotify" : "https://open.spotify.com/episode/5S4DpowyY4uAy0s3Y8mqqi"
-}, {
-  "tag" : "gag317",
-  "title" : "Roger Tichborne – die wundersame Rückkehr des Sohnes",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000539149490",
-  "url_spotify" : "https://open.spotify.com/episode/3lPJ3bfRHWDBnOTOIHgVly"
-}, {
-  "tag" : "gag316",
-  "title" : "Die Shakespeare-Unruhen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000538431068",
-  "url_spotify" : "https://open.spotify.com/episode/2BRJfJZOSstye79sh3yo0n"
-}, {
-  "tag" : "gag315",
-  "title" : "Der Mehlkrieg von 1775",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000537706361",
-  "url_spotify" : "https://open.spotify.com/episode/37O2nSkHJWGFl6CJedKxjy"
-}, {
-  "tag" : "gag314",
-  "title" : "Eine kurze Geschichte der Cholera",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000536965827",
-  "url_spotify" : "https://open.spotify.com/episode/3qVR2NIRWhqU0xRl0u7qie"
-}, {
-  "tag" : "gag313",
-  "title" : "Die Geschwister Herschel",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000536247199",
-  "url_spotify" : "https://open.spotify.com/episode/6Bw5vncNzYDijOI66EHQMm"
-}, {
-  "tag" : "gag312",
-  "title" : "Der beste aller Ritter – das Leben von Guillaume le Maréchal",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000535387902",
-  "url_spotify" : "https://open.spotify.com/episode/3sg79xnYzX0p7f9p1PhL7X"
-}, {
-  "tag" : "gag311",
-  "title" : "Der Imjin-Krieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000534669384",
-  "url_spotify" : "https://open.spotify.com/episode/1eVkt34mAAt1GPLWYyzbmh"
-}, {
-  "tag" : "gag310",
-  "title" : "Arbeitskampf, Streik und das Leben der Gewerkschaftspionierin Paula Thiede",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000533962682",
-  "url_spotify" : "https://open.spotify.com/episode/0acf38Vkr4bY2CuSQxviF3"
-}, {
-  "tag" : "gag309",
-  "title" : "Die Bestie des Gévaudan",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000533067723",
-  "url_spotify" : "https://open.spotify.com/episode/64qYMdUQJ2J3o7r8opC8e7"
-}, {
-  "tag" : "gag308",
-  "title" : "Eine kurze Geschichte des Urlaubs und Reisens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000532360410",
-  "url_spotify" : "https://open.spotify.com/episode/1i3WcPDk4FtbArHSdahwWd"
-}, {
-  "tag" : "gag307",
-  "title" : "Njinga, Königin von Ndongo und Matamba",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000531684024",
-  "url_spotify" : "https://open.spotify.com/episode/29qCYhhk5Z3BiijVkqvgSj"
-}, {
-  "tag" : "gag306",
-  "title" : "Motoren, Krieg und Inflation – Aufstieg und Fall des Unternehmers Camillo Castiglioni",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000530952734",
-  "url_spotify" : "https://open.spotify.com/episode/2ok4FJPMqadmgj7LlM5kZv"
-}, {
-  "tag" : "gag305",
-  "title" : "Der Piltdown-Mensch",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000530257591",
-  "url_spotify" : "https://open.spotify.com/episode/4SHc9PD5EmM0MVpPxiH7WW"
-}, {
-  "tag" : "gag304",
-  "title" : "Der Falschgeldbetrug von Alves dos Reis",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000529559340",
-  "url_spotify" : "https://open.spotify.com/episode/1Dsg5WKRrtArbKnSU1Pd1n"
-}, {
-  "tag" : "gag303",
-  "title" : "Brunelleschi und die Kathedrale von Florenz",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000528830787",
-  "url_spotify" : "https://open.spotify.com/episode/2R1ib1bS7pkv9l9kA3Xs1K"
-}, {
-  "tag" : "gag302",
-  "title" : "Sealand und die Gründung einer Mikronation",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000528090756",
-  "url_spotify" : "https://open.spotify.com/episode/3AwTdKy8q1rwlesIHugTe6"
-}, {
-  "tag" : "gag301",
-  "title" : "Mary Seacole",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000527334050",
-  "url_spotify" : "https://open.spotify.com/episode/45ULwRUJXEB5JUdRrEozy1"
-}, {
-  "tag" : "gag300",
-  "title" : "Der vorläufige Höhepunkt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000526584567",
-  "url_spotify" : "https://open.spotify.com/episode/5HqRQaoOzJXUZDsdGD8x6D"
-}, {
-  "tag" : "gag299",
-  "title" : "Wie Basketball von James Naismith",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000525705276",
-  "url_spotify" : "https://open.spotify.com/episode/57rwoaE7gtgR4vQaHNQGyQ"
-}, {
-  "tag" : "gag298",
-  "title" : "Die Grüne Fee und der Absinthismus",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000524749863",
-  "url_spotify" : "https://open.spotify.com/episode/0MLTbFe0v7dttb6vUI7caQ"
-}, {
-  "tag" : "gag297",
-  "title" : "Die Revolutionärin und (fast) vergessene Pionierin der Frauenbewegung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000523891170",
-  "url_spotify" : "https://open.spotify.com/episode/5pE0gg7iOCuu8RBKVOKfMu"
-}, {
-  "tag" : "gag296",
-  "title" : "Jeanne la Flamme und der bretonische Erbfolgekrieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000523142542",
-  "url_spotify" : "https://open.spotify.com/episode/5lYNH3hXimieEjxcP8sAZc"
-}, {
-  "tag" : "gag295",
-  "title" : "Die Verwandlung des Axolotls",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000522310353",
-  "url_spotify" : "https://open.spotify.com/episode/6LBjT0ZXn0IkykpUZy8O4M"
-}, {
-  "tag" : "gag294",
-  "title" : "Erwin Kreuz",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000521425513",
-  "url_spotify" : "https://open.spotify.com/episode/5TkgEvuykn8KAizrLhh1Ax"
-}, {
-  "tag" : "gag293",
-  "title" : "Als in Europa Menschen ausgestellt wurden",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000520236205",
-  "url_spotify" : "https://open.spotify.com/episode/7zanBcCWEN2tJzxGutdJAm"
-}, {
-  "tag" : "gag292",
-  "title" : "Paul Grüninger",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000518971209",
-  "url_spotify" : "https://open.spotify.com/episode/4BWme3KK5tJdb7pN3NkJj7"
-}, {
-  "tag" : "gag291",
-  "title" : "Ein erfolgreicher Kampf gegen die Kolonialisierung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000518012613",
-  "url_spotify" : "https://open.spotify.com/episode/5JQnJyUmZrVj8IV4FvCFlE"
-}, {
-  "tag" : "gag290",
-  "title" : "Der Angriff der Leichten Brigade",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000517078344",
-  "url_spotify" : "https://open.spotify.com/episode/6PH0kizGCb2QwZgJxTcje5"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000515799265",
-  "url_spotify" : "https://open.spotify.com/episode/1Mb1yjgq7YTJtnZ1WyrngK",
-  "title" : "Dr. Emma Southon on murder in ancient Rome",
-  "tag" : "extra"
-}, {
-  "tag" : "gag289",
-  "title" : "Ein Kreuzzug, der einen ungeahnten Verlauf nahm",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000516108030",
-  "url_spotify" : "https://open.spotify.com/episode/71eMH7rr2I5jT5ziX9BcbU"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000515799265",
-  "url_spotify" : "https://open.spotify.com/episode/1Mb1yjgq7YTJtnZ1WyrngK",
-  "title" : "Dr. Emma Southon on murder in ancient Rome",
-  "tag" : "extra"
-}, {
-  "tag" : "gag288",
-  "title" : "Der Senat, der über Leichen ging",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000515145206",
-  "url_spotify" : "https://open.spotify.com/episode/0r8HST99XHE91JmyxBBUMw"
-}, {
-  "tag" : "gag287",
-  "title" : "Eine kurze Geschichte des Ballonfahrens und Fallschirmspringens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000514195264",
-  "url_spotify" : "https://open.spotify.com/episode/428jIJI3yKiVgorAxTKblO"
-}, {
-  "tag" : "gag286",
-  "title" : "Die verschwundenen Seefrauen Islands",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000513393623",
-  "url_spotify" : "https://open.spotify.com/episode/5iybS0Wp7P8IislwhMHqfq"
-}, {
-  "tag" : "gag285",
-  "title" : "Joseph Petrosino und die Black Hand",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000512365861",
-  "url_spotify" : "https://open.spotify.com/episode/05yQj3kbs0Amk8kXVEWtZv"
-}, {
-  "tag" : "gag284",
-  "title" : "\"There is death in the pot\" - Friedrich Accum und die Lebensmittelfälscher",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000511400883",
-  "url_spotify" : "https://open.spotify.com/episode/1PKaZ00iZL66kg9NxWcjwL"
-}, {
-  "tag" : "gag283",
-  "title" : "Lola Montez",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000510441079",
-  "url_spotify" : "https://open.spotify.com/episode/0V4uFcJh3PcShWwUQ2jqP6"
-}, {
-  "tag" : "gag282",
-  "title" : "Fredegund, Brunhild und der merowingische Bruderkrieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000509506957",
-  "url_spotify" : "https://open.spotify.com/episode/3IltSeST6fWdMx80dGkmbi"
-}, {
-  "tag" : "gag281",
-  "title" : "Der Putschversuch vom 23. Februar 1981",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000508435496",
-  "url_spotify" : "https://open.spotify.com/episode/6cVLdv70hpbOG8memCqEpr"
-}, {
-  "tag" : "gag280",
-  "title" : "Der versunkene Kontinent Lemuria",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000507549646",
-  "url_spotify" : "https://open.spotify.com/episode/1iBQWToyTEVoDfVC8PMLz5"
-}, {
-  "tag" : "gag279",
-  "title" : "Muskat und Manhattan",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000506730217",
-  "url_spotify" : "https://open.spotify.com/episode/3jrBBFZCntkOjQCiBv2d2x"
-}, {
-  "tag" : "gag278",
-  "title" : "Von göttlichen Robotern und feuerspeienden Bullen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000505898445",
-  "url_spotify" : "https://open.spotify.com/episode/6SgnyB2enAXngAyhQvgdSX"
-}, {
-  "tag" : "gag277",
-  "title" : "Der Aufstand und Putsch von Wilmington",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000505176566",
-  "url_spotify" : "https://open.spotify.com/episode/2ByFSLiciEnYfD2X30ZZ00"
-}, {
-  "tag" : "gag276",
-  "title" : "Aufruhr am Sankt-Scholastika-Tag",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000504496046",
-  "url_spotify" : "https://open.spotify.com/episode/6Dd7nKl0XsPKPEgOzusBLi"
-}, {
-  "tag" : "gag275",
-  "title" : "Victor Lustig – Der Mann, der den Eiffelturm verkaufte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000503871113",
-  "url_spotify" : "https://open.spotify.com/episode/7LCVdNKD0xJ8R8XWM0OuM7"
-}, {
-  "tag" : "gag274",
-  "title" : "Das Petzvalobjektiv",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000503291159",
-  "url_spotify" : "https://open.spotify.com/episode/1kzF1FcXkLGCw5cQzeVYK9"
-}, {
-  "tag" : "gag273",
-  "title" : "Der Alchemist und Goldmacher Franz Tausend",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000502562017",
-  "url_spotify" : "https://open.spotify.com/episode/34uKJ1Mq2kEIaJZbVI2NFE"
-}, {
-  "tag" : "gag272",
-  "title" : "Am Ende der Welt - Napoleons letzte Jahre im Exil",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000501809308",
-  "url_spotify" : "https://open.spotify.com/episode/2gMwsGrfYSqnBADTokrXsv"
-}, {
-  "tag" : "gag271",
-  "title" : "Caroline Neuber und der Hanswurststreit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000501061756",
-  "url_spotify" : "https://open.spotify.com/episode/6jTT98XS4sIyUA07rZ2lL7"
-}, {
-  "tag" : "gag270",
-  "title" : "Eine thüringische Katastrophe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000500222396",
-  "url_spotify" : "https://open.spotify.com/episode/2gRXvVETCvHR8ZP245Fwwj"
-}, {
-  "tag" : "gag269",
-  "title" : "Monika Ertl und ein Mord im Generalkonsulat",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000499183420",
-  "url_spotify" : "https://open.spotify.com/episode/5lmRE8EgSnQHKDGcNB07T2"
-}, {
-  "tag" : "gag268",
-  "title" : "Die Gebrüder Kellogg und die Erfindung des Frühstücks",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000498115094",
-  "url_spotify" : "https://open.spotify.com/episode/3dpr9peQml4hr8CCoaKvgb"
-}, {
-  "tag" : "gag267",
-  "title" : "Die Leichensynode von 897",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000497167975",
-  "url_spotify" : "https://open.spotify.com/episode/4oOUE9NmdnhKHsrqtUUEMB"
-}, {
-  "tag" : "gag266",
-  "title" : "Die Schlacht von Azincourt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000496401450",
-  "url_spotify" : "https://open.spotify.com/episode/2Pa7dgEQOObOPvtLvRpafB"
-}, {
-  "tag" : "gag265",
-  "title" : "Syphilis und die Tuskegee-Syphilis-Studie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000495539319",
-  "url_spotify" : "https://open.spotify.com/episode/6xeEjiDXOwnRdrzJvGAmz9"
-}, {
-  "tag" : "gag264",
-  "title" : "Seondeok, erste Königin Koreas",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000494820355",
-  "url_spotify" : "https://open.spotify.com/episode/281YcEOja1h3ad6ovSl2SP"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000494686309",
-  "url_spotify" : "https://open.spotify.com/episode/20cc2z3Hi67gj3kIFMJZPo",
-  "title" : "Ein Geschichten-Extra mit Monika Ankele über Psychiatriegeschichte",
-  "tag" : "extra"
-}, {
-  "tag" : "gag263",
-  "title" : "Lavoisier und die Entdeckung des Sauerstoffs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000493989583",
-  "url_spotify" : "https://open.spotify.com/episode/6rRQC3h7IVZy9wCauf3hqO"
-}, {
-  "tag" : "gag262",
-  "title" : "Die Strawhat Riots",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000493157941",
-  "url_spotify" : "https://open.spotify.com/episode/6zwNJxGTxAPDZ2QqBobiEd"
-}, {
-  "tag" : "gag261",
-  "title" : "Adam Worth, der Napoleon des Verbrechens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000492312289",
-  "url_spotify" : "https://open.spotify.com/episode/1Nf9a51xLdafqFnzIPLsin"
-}, {
-  "tag" : "gag260",
-  "title" : "Der Rattenfänger von Hameln",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000491480850",
-  "url_spotify" : "https://open.spotify.com/episode/2LLhiW5tQfoXMGYFOIo5bv"
-}, {
-  "tag" : "gag259",
-  "title" : "Operation Mincemeat – Eine Geheimdienstaktion während des Zweiten Weltkriegs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000490585058",
-  "url_spotify" : "https://open.spotify.com/episode/2XWlZYZBNxXHY4FeLd9Q8A"
-}, {
-  "tag" : "gag258",
-  "title" : "Der Andrews Raid - Eine Lokomotive auf Abwegen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000489908196",
-  "url_spotify" : "https://open.spotify.com/episode/1YUCLumEBVY35EYzHSCiYU"
-}, {
-  "tag" : "gag257",
-  "title" : "Alexander von Humboldt – Bugtales.FM Crossover",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000489210531",
-  "url_spotify" : "https://open.spotify.com/episode/4s0F8AoCsEFrL7xZLrW2Br"
-}, {
-  "tag" : "gag256",
-  "title" : "Der Rütlischwur und die Anfänge der Schweizerischen Eidgenossenschaft",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000488589934",
-  "url_spotify" : "https://open.spotify.com/episode/5uwiImm4z32jx5lQMu9qmk"
-}, {
-  "tag" : "gag255",
-  "title" : "Die 47 Ronin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000487885175",
-  "url_spotify" : "https://open.spotify.com/episode/4VHECyzkXpF72EHMxIlhOm"
-}, {
-  "tag" : "gag254",
-  "title" : "Eine kurze Geschichte des Kautschuks",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000487164327",
-  "url_spotify" : "https://open.spotify.com/episode/4JnXaRpQM43B55RaiV2Deg"
-}, {
-  "tag" : "gag253",
-  "title" : "Martin Frobisher und die Steine",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000486471864",
-  "url_spotify" : "https://open.spotify.com/episode/5uR9wfk12K452UG5StoqNW"
-}, {
-  "tag" : "gag252",
-  "title" : "Harvard Computers – Wie Astronominnen die Sterne neu sortierten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000485689906",
-  "url_spotify" : "https://open.spotify.com/episode/4Dza83xmUd3rbn49alkxvA"
-}, {
-  "tag" : "gag251",
-  "title" : "Der Schachtürke",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000484995557",
-  "url_spotify" : "https://open.spotify.com/episode/1VnHUgoLUrkLWKBGZDjMNZ"
-}, {
-  "tag" : "gag250",
-  "title" : "Eine kurze Geschichte der Bluttransfusion",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000483473726",
-  "url_spotify" : "https://open.spotify.com/episode/6TTZPRYdWtFbKdK9pBstwW"
-}, {
-  "tag" : "gag249",
-  "title" : "Das Malireich und die Pilgerreise des vielleicht reichsten Mannes der Geschichte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000481693164",
-  "url_spotify" : "https://open.spotify.com/episode/78jVxozQ9jJFJ1STOgL1XO"
-}, {
-  "tag" : "gag248",
-  "title" : "Der Venustransit von 1761/69 und das erste wissenschaftliche Großprojekt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000479385823",
-  "url_spotify" : "https://open.spotify.com/episode/01etzc2J3No5zl0PLR9duV"
-}, {
-  "tag" : "gag247",
-  "title" : "Der Emu Krieg von 1932",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000478305863",
-  "url_spotify" : "https://open.spotify.com/episode/6S9DzR3yy6lm1Yv9UmmJlg"
-}, {
-  "tag" : "gag246",
-  "title" : "John Law und die Mississippi-Blase",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000477396158",
-  "url_spotify" : "https://open.spotify.com/episode/4XilWwtkAffSpiQltWYUsi"
-}, {
-  "tag" : "gag245",
-  "title" : "Operation Paul Bunyan",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000476630178",
-  "url_spotify" : "https://open.spotify.com/episode/4qrqhYu95WE1qhpTYuecZK"
-}, {
-  "tag" : "gag244",
-  "title" : "Die Mühle von Auriol und warum ihre Zerstörung eine Besetzung Frankreichs verhindert hat",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000475920023",
-  "url_spotify" : "https://open.spotify.com/episode/0CIafalUvNJBmfci0ih3Kq"
-}, {
-  "tag" : "gag243",
-  "title" : "Aeneas Coffey und eine kleine Geschichte des irischen Whiskeys",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000475174707",
-  "url_spotify" : "https://open.spotify.com/episode/0IBffZqWaGFFwhSe8TYQBC"
-}, {
-  "tag" : "gag242",
-  "title" : "Eine kurze Geschichte der Olympischen Spiele (der Neuzeit)",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000474438815",
-  "url_spotify" : "https://open.spotify.com/episode/5E5noAboagdqcs8wF56GlK"
-}, {
-  "tag" : "gag241",
-  "title" : "General Königsmarck und der größte Kunstraub aller Zeiten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000473745640",
-  "url_spotify" : "https://open.spotify.com/episode/3wx3TWEqJ4R2mgjy8yu2Dj"
-}, {
-  "tag" : "gag240",
-  "title" : "René Blondlot und die Entdeckung der N-Strahlen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000473003049",
-  "url_spotify" : "https://open.spotify.com/episode/1TQX5qqSeBEK4tzpE0MLHG"
-}, {
-  "tag" : "gag239",
-  "title" : "Die Zabern-Affäre",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000472270110",
-  "url_spotify" : "https://open.spotify.com/episode/2IvnbdZydBO7Pw9rdojrJV"
-}, {
-  "tag" : "gag238",
-  "title" : "Kurze Geschichten ausgestorbener Berufe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000471534492",
-  "url_spotify" : "https://open.spotify.com/episode/6uFqN11ZoRY47fXefeHiyu"
-}, {
-  "tag" : "gag237",
-  "title" : "Friedrich Anton Mesmer und der Animalische Magnetismus",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000470854979",
-  "url_spotify" : "https://open.spotify.com/episode/07dtYVbGDa8T2no1Uc6ljR"
-}, {
-  "tag" : "gag236",
-  "title" : "Monopoly – Die Geschichte eines Brettspiels",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000470169170",
-  "url_spotify" : "https://open.spotify.com/episode/76lqMcKa2xyVxYDu1rx1wb"
-}, {
-  "tag" : "gag235",
-  "title" : "Die Quarzkrise",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000469442938",
-  "url_spotify" : "https://open.spotify.com/episode/1NRReziTN60F4wuP1IYLPI"
-}, {
-  "tag" : "gag234",
-  "title" : "Das bekannteste Parfüm der Welt und seine russische Vorgeschichte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000468762068",
-  "url_spotify" : "https://open.spotify.com/episode/6rL6rghyTzhtdohnRDv7VM"
-}, {
-  "tag" : "gag233",
-  "title" : "Norton I., Kaiser der USA",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000468084892",
-  "url_spotify" : "https://open.spotify.com/episode/1KFu2JGCrSwcfFHEGyCqfh"
-}, {
-  "tag" : "gag232",
-  "title" : "Ein Mordfall und das umfangreichste Wörterbuch der englischen Sprache",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000467417218",
-  "url_spotify" : "https://open.spotify.com/episode/5S24PAAGzqyuFA1UlNldHX"
-}, {
-  "tag" : "gag231",
-  "title" : "Die Große Enttäuschung von 1844",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000466728211",
-  "url_spotify" : "https://open.spotify.com/episode/7Bd0WcREpgDeNtlw1NgzGv"
-}, {
-  "tag" : "gag230",
-  "title" : "Die Tendaguru-Expedition und das größte Dinosaurierskelett der Welt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000466047536",
-  "url_spotify" : "https://open.spotify.com/episode/7tznuBeYsC8YFKKuUdRO9U"
-}, {
-  "tag" : "gag229",
-  "title" : "Elisabeth Báthory, die (angebliche) Blutgräfin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000465362101",
-  "url_spotify" : "https://open.spotify.com/episode/3NlBPVUqWCg4kGrNhv7GGy"
-}, {
-  "tag" : "gag228",
-  "title" : "Berliner Blau – die Erfindung einer Farbe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000464675000",
-  "url_spotify" : "https://open.spotify.com/episode/6uDvjQyFjbByhT99vskAgO"
-}, {
-  "tag" : "gag227",
-  "title" : "Die unsterbliche Henrietta Lacks",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000463992757",
-  "url_spotify" : "https://open.spotify.com/episode/4IQYagq53IgVkUWVCJzalB"
-}, {
-  "tag" : "gag226",
-  "title" : "Der Untergang der Batavia",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000463335902",
-  "url_spotify" : "https://open.spotify.com/episode/66kjOfaMhCutkqF3TDmaeT"
-}, {
-  "tag" : "gag225",
-  "title" : "Die Rundfahrt der Schlachtfelder",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000462559652",
-  "url_spotify" : "https://open.spotify.com/episode/0fTXwrcCDDCFsDPUpXfs13"
-}, {
-  "tag" : "gag224",
-  "title" : "Die Balmis-Expedition und eine kurze Geschichte der Pockenimpfung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000461892380",
-  "url_spotify" : "https://open.spotify.com/episode/4A7aE63NKR7jf7tTxZlx2m"
-}, {
-  "tag" : "gag223",
-  "title" : "Ramen und die Transformation Japans",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000461288040",
-  "url_spotify" : "https://open.spotify.com/episode/50h6f1FrFNT6llalMjSO3G"
-}, {
-  "tag" : "gag222",
-  "title" : "Das Voynich-Manuskript",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000460725936",
-  "url_spotify" : "https://open.spotify.com/episode/4FvRgif4UcXZOjF1fkPajK"
-}, {
-  "tag" : "gag221",
-  "title" : "Hans Staden - ein Landsknecht bei den Menschenfressern",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000459951309",
-  "url_spotify" : "https://open.spotify.com/episode/1d3tER1qt0pY7EehCOM3Mk"
-}, {
-  "tag" : "gag220",
-  "title" : "Eine kurze Geschichte der Rohrpost",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000459280058",
-  "url_spotify" : "https://open.spotify.com/episode/1YL2gWjlxSqqzqYDD4WbdP"
-}, {
-  "tag" : "gag219",
-  "title" : "Die Kotze-Affäre",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000458628401",
-  "url_spotify" : "https://open.spotify.com/episode/3jv6WCyW2LwKmStsvXHtx1"
-}, {
-  "tag" : "gag218",
-  "title" : "Die Pazzi-Verschwörung und der Aufstieg der Medici",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000457994313",
-  "url_spotify" : "https://open.spotify.com/episode/3cU4QJdlNWPHWSPtDkEWUg"
-}, {
-  "tag" : "gag217",
-  "title" : "Wie Joseph Haydn den Kopf verlor",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000457322177",
-  "url_spotify" : "https://open.spotify.com/episode/2vRfkomN5tuQFDEZUPIRWP"
-}, {
-  "tag" : "gag216",
-  "title" : "Napoleon II. – Vom König von Rom zum Herzog von Reichstadt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000456676271",
-  "url_spotify" : "https://open.spotify.com/episode/63mst94aiuQK6jDrd57LYD"
-}, {
-  "tag" : "gag215",
-  "title" : "Wojtek, polnischer Soldatenbär",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000456064465",
-  "url_spotify" : "https://open.spotify.com/episode/53U4h83kSsW7e2uoknoeqf"
-}, {
-  "tag" : "gag214",
-  "title" : "Hedy Lamarr – Hollywoodstar und Erfinderin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000455477289",
-  "url_spotify" : "https://open.spotify.com/episode/3iGpL3K2W0FMFjBPu6qDWQ"
-}, {
-  "tag" : "gag213",
-  "title" : "Tom Morris und eine kleine Geschichte des Golfsports",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000454580729",
-  "url_spotify" : "https://open.spotify.com/episode/0j0fkWTTVaf8ccSlmoRWw3"
-}, {
-  "tag" : "gag212",
-  "title" : "Eine kleine Geschichte der Sternbilder",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000453701477",
-  "url_spotify" : "https://open.spotify.com/episode/3Ldr3CI7GygvKTA52oUaDv"
-}, {
-  "tag" : "gag211",
-  "title" : "Griechisches Feuer",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000452867746",
-  "url_spotify" : "https://open.spotify.com/episode/7KZiBeKYKzwMI28FCqanbq"
-}, {
-  "tag" : "gag210",
-  "title" : "Der Kunstfälscher Han van Meegeren",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000452007215",
-  "url_spotify" : "https://open.spotify.com/episode/0w4QdoLGFw9NYKCRMojetw"
-}, {
-  "tag" : "gag209",
-  "title" : "Cyriacus und die Erfindung der Archäologie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000451154292",
-  "url_spotify" : "https://open.spotify.com/episode/05u0WBjX7MzJNWRDObp5Yq"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000450675527",
-  "url_spotify" : "https://open.spotify.com/episode/58j4AKnlXQdXwbXMPlm6cB",
-  "title" : "Interview mit René Feldvoß über Eishockey in der DDR",
-  "tag" : "extra"
-}, {
-  "tag" : "gag208",
-  "title" : "Die kleinste Liga der Welt – Eishockey in der DDR",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000450192112",
-  "url_spotify" : "https://open.spotify.com/episode/2WambpsX4xKVMJhSp9Uc5n"
-}, {
-  "tag" : "gag207",
-  "title" : "William Stewart Halsted und die Chirurgie des 19. Jahrhunderts",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000449353568",
-  "url_spotify" : "https://open.spotify.com/episode/7biu92UAyqAKL7Aw2qW14h"
-}, {
-  "tag" : "gag206",
-  "title" : "Von Verliesen & Drachen - ein 3W6 Crossover",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000448529208",
-  "url_spotify" : "https://open.spotify.com/episode/3bZ8y6bk6KJpWbVzyc5pWD"
-}, {
-  "tag" : "gag205",
-  "title" : "Die Befreiung von Schloss Itter",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000447991082",
-  "url_spotify" : "https://open.spotify.com/episode/15haRi9o6LkGJtdWn5a13R"
-}, {
-  "tag" : "gag204",
-  "title" : "Obaysch - das viktorianische Nilpferd",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000447421816",
-  "url_spotify" : "https://open.spotify.com/episode/3Al3zZ5OVcNLswzCjluuxH"
-}, {
-  "tag" : "gag203",
-  "title" : "Bleiben oder gehen? Die Option in Südtirol 1939",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000446871758",
-  "url_spotify" : "https://open.spotify.com/episode/1b2XC5z4HRz9EvARjZvTXV"
-}, {
-  "tag" : "gag202",
-  "title" : "Über Brunzdoktoren und Uroskopie – die Harnschau in der vormodernen Medizin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000446345220",
-  "url_spotify" : "https://open.spotify.com/episode/6uWNzzJe8YBmENSnBUrVVB"
-}, {
-  "tag" : "gag201",
-  "title" : "Eine kleine Geschichte des Speiseeises",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000445770328",
-  "url_spotify" : "https://open.spotify.com/episode/5OLtNdeUIwvFR110iMIjqp"
-}, {
-  "tag" : "gag200",
-  "title" : "Eine Abrechnung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000445199189",
-  "url_spotify" : "https://open.spotify.com/episode/4I6YUm7gC7wR6d9s1RNcke"
-}, {
-  "tag" : "gag199",
-  "title" : "UC 71 und der U-Boot-Krieg im Ersten Weltkrieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000444665828",
-  "url_spotify" : "https://open.spotify.com/episode/7zKNfK676AJizWLYjschd2"
-}, {
-  "tag" : "gag198",
-  "title" : "Olga von Kiew oder Mit den Spatzen kam der Tod",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000444106397",
-  "url_spotify" : "https://open.spotify.com/episode/298XSx6KlgNvrE1CgAJkVb"
-}, {
-  "tag" : "gag197",
-  "title" : "Das kurzlebige Königreich Finnland – und ein deutscher Adliger auf dem Thron",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000443514409",
-  "url_spotify" : "https://open.spotify.com/episode/4L1V6BOtmBCYeipB0S5TST"
-}, {
-  "tag" : "gag196",
-  "title" : "Wie der Panamakanal entstand",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000442797339",
-  "url_spotify" : "https://open.spotify.com/episode/1h9cCZYMnASrFfWUbyU20q"
-}, {
-  "tag" : "gag195",
-  "title" : "Wie Gerta Stern auf der Flucht nach Panama ihren Mann aus dem KZ befreite",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000442017788",
-  "url_spotify" : "https://open.spotify.com/episode/505zsY5t1hcYF1QB2DhDeC"
-}, {
-  "tag" : "gag194",
-  "title" : "Die Natchez und der französische Kolonialismus in Nordamerika",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000441261870",
-  "url_spotify" : "https://open.spotify.com/episode/6paMx5fL5mVRU6xUyjv5vS"
-}, {
-  "tag" : "gag193",
-  "title" : "Kanton Übrig – Wie Vorarlberg 1919 nicht der Schweiz beitrat",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000440652549",
-  "url_spotify" : "https://open.spotify.com/episode/2OwrFvo67U1iFbsV6Howk0"
-}, {
-  "tag" : "gag192",
-  "title" : "Tiere vor Gericht",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000440026400",
-  "url_spotify" : "https://open.spotify.com/episode/13aKee02ff9zfqquLVItZZ"
-}, {
-  "tag" : "gag191",
-  "title" : "Aethelfled - Warrior Queen of Mercia",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000439037639",
-  "url_spotify" : "https://open.spotify.com/episode/1GvFG7NmK5KEtUVvzrdSIW"
-}, {
-  "tag" : "gag190",
-  "title" : "Die Assassinen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000438142394",
-  "url_spotify" : "https://open.spotify.com/episode/6ZKhMG5jEdglyYAsnkcKiQ"
-}, {
-  "tag" : "gag189",
-  "title" : "Die Schlacht bei Cannae",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000437494250",
-  "url_spotify" : "https://open.spotify.com/episode/2aAwKocigYRFZmpon0lUYO"
-}, {
-  "tag" : "gag188",
-  "title" : "Martin Couney und die Inkubator-Ausstellungen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000436967239",
-  "url_spotify" : "https://open.spotify.com/episode/6MFw85TttCLPOVVphfhqCQ"
-}, {
-  "tag" : "gag187",
-  "title" : "Die Wiener Weltausstellung von 1873",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000436243122",
-  "url_spotify" : "https://open.spotify.com/episode/1BddsfCQlOOdy2xopoOyFd"
-}, {
-  "tag" : "gag186",
-  "title" : "Die Redlichen Pioniere von Rochdale und eine kurze Geschichte der Genossenschaften",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000435127029",
-  "url_spotify" : "https://open.spotify.com/episode/2pTXHOEEh8C4aEravQ6FN9"
-}, {
-  "tag" : "gag185",
-  "title" : "Kleindeutschland und die General Slocum Katastrophe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000434578654",
-  "url_spotify" : "https://open.spotify.com/episode/5eYMt2uJjoA7eGRfLU0zBP"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000434325316",
-  "url_spotify" : "https://open.spotify.com/episode/2L09bRqv9u7KZKEyqOaX1x",
-  "title" : "Revolution 1918/19 in Bayern",
-  "tag" : "extra"
-}, {
-  "tag" : "gag184",
-  "title" : "Katharina Kepler – ein Hexenprozess in der Frühen Neuzeit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000434026525",
-  "url_spotify" : "https://open.spotify.com/episode/7IYbQOhjOUVSM9Uh3tXT4A"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000433780673",
-  "url_spotify" : "https://open.spotify.com/episode/7z5e4jcnxTzNPNGcoSetmR",
-  "title" : "Dr. Emma Southon on Agrippina the Younger",
-  "tag" : "extra"
-}, {
-  "tag" : "gag183",
-  "title" : "Agrippina die Jüngere, mächtigste Frau der frühen Kaiserzeit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000433565458",
-  "url_spotify" : "https://open.spotify.com/episode/3gYzbBBBWHKBGG2LzSsvCu"
-}, {
-  "tag" : "gag182",
-  "title" : "Der Zündholzkönig Ivar Kreuger",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000432471707",
-  "url_spotify" : "https://open.spotify.com/episode/3S4fAHnZJPs5dm5Kuj43OG"
-}, {
-  "tag" : "gag181",
-  "title" : "Von Gulasch, Pörkölt und Nationalgerichten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000431676040",
-  "url_spotify" : "https://open.spotify.com/episode/422QlqD6qHEN4p44QMKItQ"
-}, {
-  "tag" : "gag180",
-  "title" : "Die Gelbe Flotte – ein Schiffskonvoi zwischen den Fronten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000431200601",
-  "url_spotify" : "https://open.spotify.com/episode/5TpMZvVMReA0lXiMDLSsPO"
-}, {
-  "tag" : "gag179",
-  "title" : "Maria Sibylla Merian – Naturforscherin und Künstlerin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000430719556",
-  "url_spotify" : "https://open.spotify.com/episode/7E6A9hsQCiExsRSOZvGKp1"
-}, {
-  "tag" : "gag178",
-  "title" : "Der Klosterskandal von Sant'Ambrogio",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000430242382",
-  "url_spotify" : "https://open.spotify.com/episode/4tDSryeauuSIOs6AteWmU8"
-}, {
-  "tag" : "gag177",
-  "title" : "Robert Fortune, Botaniker und Teespion",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000429772766",
-  "url_spotify" : "https://open.spotify.com/episode/2DnuYm5LH0S0DlGT4FW5kA"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000429921476",
-  "url_spotify" : "https://open.spotify.com/episode/73mGGXf7QSw7eXbotzNXEO",
-  "title" : "Margiana – ein Interview mit Rainer-Maria Weiss, Direktor des Archäologischen Museums in Hamburg",
-  "tag" : "extra"
-}, {
-  "tag" : "gag176",
-  "title" : "Die Anfänge des Anarchismus und was Uhrmacher in der Schweiz damit zu tun haben",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000429294962",
-  "url_spotify" : "https://open.spotify.com/episode/1tTiVaB5nK8dhlmFeVu6Jq"
-}, {
-  "tag" : "gag175",
-  "title" : "C.W. Field und das erste Kabel durch den Atlantik",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000428771814",
-  "url_spotify" : "https://open.spotify.com/episode/00wGKCs2eqyvBB34BYeDbW"
-}, {
-  "tag" : "gag174",
-  "title" : "Harriet Tubman und die Underground Railroad",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000428302998",
-  "url_spotify" : "https://open.spotify.com/episode/1HUjZ1rrvh2jmke7uLgjCi"
-}, {
-  "tag" : "gag173",
-  "title" : "Der gefährliche Garten von Vaux-le-Vicomte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000427760439",
-  "url_spotify" : "https://open.spotify.com/episode/31mk3Wah0SFjw8FKNpBFkg"
-}, {
-  "tag" : "gag172",
-  "title" : "Eine kurze Geschichte der Armut in der Frühen Neuzeit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000427298306",
-  "url_spotify" : "https://open.spotify.com/episode/3z2ZNQaAYKtCx63XQxpj8R"
-}, {
-  "tag" : "gag171",
-  "title" : "Eine ganz kleine Geschichte der Nacht und des Schlafs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000426862065",
-  "url_spotify" : "https://open.spotify.com/episode/3hdCRJtnhyMKvuil8xoDrA"
-}, {
-  "tag" : "gag170",
-  "title" : "Auf Schatzsuche",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000426510560",
-  "url_spotify" : "https://open.spotify.com/episode/6U1zjQPNqXMDnSCmiUn82m"
-}, {
-  "tag" : "gag169",
-  "title" : "Maos Großer Sprung und die chinesische Hungersnot von 1958–62",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000426107644",
-  "url_spotify" : "https://open.spotify.com/episode/5xAvIJSjNKgGoa104FPrMY"
-}, {
-  "tag" : "gag168",
-  "title" : "Carl Laemmle und die Anfänge Hollywoods",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000425644008",
-  "url_spotify" : "https://open.spotify.com/episode/3dUHpIQYSM7d0ClnusTe9C"
-}, {
-  "tag" : "gag167",
-  "title" : "Mary Toft und die Hasen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000425183366",
-  "url_spotify" : "https://open.spotify.com/episode/6ctxgWRiThdTPBxGOnFG4v"
-}, {
-  "tag" : "gag166",
-  "title" : "Siegmund Bosel – die wechselvolle Geschichte eines Inflationskönigs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000424722902",
-  "url_spotify" : "https://open.spotify.com/episode/78Ddnbu5C3HwbOXaIuczM2"
-}, {
-  "tag" : "gag165",
-  "title" : "Pius IX. und die kurzlebige Römische Republik von 1849",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000424281431",
-  "url_spotify" : "https://open.spotify.com/episode/2cT87WWeGnydYlg1eu48bt"
-}, {
-  "tag" : "gag164",
-  "title" : "Eine kurze Geschichte des Alkoholkonsums",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000423828888",
-  "url_spotify" : "https://open.spotify.com/episode/0xQIf6lNrqeegnHycv8ffA"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000423576091",
-  "url_spotify" : "https://open.spotify.com/episode/38QAuVHOOndmL8TEpx1rLc",
-  "title" : "Dirk Liesemer über den Aufstand der Matrosen und den Beginn der Revolution",
-  "tag" : "extra"
-}, {
-  "tag" : "gag163",
-  "title" : "Vernepator Cur - der Hund im Hamsterrad",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000423378132",
-  "url_spotify" : "https://open.spotify.com/episode/6JH4fAGaYsleYrWMfI1ogP"
-}, {
-  "tag" : "gag162",
-  "title" : "Novemberrevolution und die mehrfache Ausrufung der Republik",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000422910993",
-  "url_spotify" : "https://open.spotify.com/episode/7GVm54v1G4k0TZycBB7P6i"
-}, {
-  "tag" : "gag161",
-  "title" : "Steamboat Arabia oder Der Schatz im Maisfeld",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000422486303",
-  "url_spotify" : "https://open.spotify.com/episode/0EUXMzrSs00zJg2kl1vQxy"
-}, {
-  "tag" : "gag160",
-  "title" : "Barbareskenstaaten und die europäischen Seemächte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000422000923",
-  "url_spotify" : "https://open.spotify.com/episode/4YYxMACsJWfPMvwIgdFzb3"
-}, {
-  "tag" : "gag159",
-  "title" : "Thorsten Logge über Geschichte und Public History",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000421480381",
-  "url_spotify" : "https://open.spotify.com/episode/0TcDRNbGTeekg88P2pkCZB"
-}, {
-  "tag" : "gag158",
-  "title" : "Al-Biruni und die erste Globalgeschichte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000420967420",
-  "url_spotify" : "https://open.spotify.com/episode/03B1Ude38Ny72dQf64NUn5"
-}, {
-  "tag" : "gag157",
-  "title" : "Salpeter – Aufstieg und Fall einer chemischen Verbindung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000420482753",
-  "url_spotify" : "https://open.spotify.com/episode/4hyyLDSROsIZARmDxa2WaG"
-}, {
-  "tag" : "gag156",
-  "title" : "Charles Lindbergh, Alexis Carrel und die Mensch-Maschine",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000420025903",
-  "url_spotify" : "https://open.spotify.com/episode/4uMtrCjIunmka2EDh2KXrb"
-}, {
-  "tag" : "gag155",
-  "title" : "Trofim Lyssenko und der Lyssenkoismus in der Sowjetunion",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000419589724",
-  "url_spotify" : "https://open.spotify.com/episode/5vr1J0GDGZ8AKtITKs7QIt"
-}, {
-  "tag" : "gag154",
-  "title" : "La Maupin, die duellierende Opernsängerin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000419145347",
-  "url_spotify" : "https://open.spotify.com/episode/4jlrykohUIpbHRT1YYJYCm"
-}, {
-  "tag" : "gag153",
-  "title" : "Wien-Tour mit Thomas Harbich (#WienFakt)",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000418706854",
-  "url_spotify" : "https://open.spotify.com/episode/53yNTXgxnhuO4i5jdNSC76"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000418482330",
-  "url_spotify" : "https://open.spotify.com/episode/0veKZbyqXYPisULIKim8vJ",
-  "title" : "Interview mit Walfried Malleskat vom Filmmuseum Bendestorf",
-  "tag" : "extra"
-}, {
-  "tag" : "gag152",
-  "title" : "Ernest Shackleton und die Endurance-Expedition",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000418282474",
-  "url_spotify" : "https://open.spotify.com/episode/4kejB2M4UEtbk0bEaiqBbA"
-}, {
-  "tag" : "gag151",
-  "title" : "Manjirō, der erste Japaner in Amerika",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000417848647",
-  "url_spotify" : "https://open.spotify.com/episode/5rS3pJyl6OMo1zhxnMz6OR"
-}, {
-  "tag" : "gag150",
-  "title" : "Die Geschichte des Filmstudios Bendestorf",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000417414098",
-  "url_spotify" : "https://open.spotify.com/episode/74hIwlNIiu7zqVdNmKYPxD"
-}, {
-  "tag" : "gag149",
-  "title" : "Die Kabeljaukriege",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000417000868",
-  "url_spotify" : "https://open.spotify.com/episode/4r32yCQw4FRLmuAYQ6e1Sg"
-}, {
-  "tag" : "gag148",
-  "title" : "Das Ende der Welt - Friedenskaiser und falsche Friedriche",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000416559918",
-  "url_spotify" : "https://open.spotify.com/episode/2FircaU9PZL663kkcaKfM0"
-}, {
-  "tag" : "gag147",
-  "title" : "Das Fräulein vom Amt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000416075998",
-  "url_spotify" : "https://open.spotify.com/episode/2aOx0EiAsGUWf1VHUGMQZX"
-}, {
-  "tag" : "gag146",
-  "title" : "Tripel-Allianz-Krieg",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000415604825",
-  "url_spotify" : "https://open.spotify.com/episode/2SLmisehzYKl5X8pBkP9Nv"
-}, {
-  "tag" : "gag145",
-  "title" : "Barbara von Cilli oder Wie eine 100 mal wiederholte Lüge zur Wahrheit wird",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000415200397",
-  "url_spotify" : "https://open.spotify.com/episode/3tRXiBN6gdSVkrVqL8HkOo"
-}, {
-  "tag" : "gag144",
-  "title" : "Die Spanische Grippe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000414732841",
-  "url_spotify" : "https://open.spotify.com/episode/52p1h2HXYJVYA0FFeRcEy3"
-}, {
-  "tag" : "gag143",
-  "title" : "Über Marsmenschen, Massenpanik und die Entstehung eines Mythos",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000414200492",
-  "url_spotify" : "https://open.spotify.com/episode/3hfe6cGkrojhSrsD3IlUYp"
-}, {
-  "tag" : "gag142",
-  "title" : "Bertha Pappenheim – Gründerin des Jüdischen Frauenbundes und Sozialpionierin",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000413633779",
-  "url_spotify" : "https://open.spotify.com/episode/6XwFMUROs8sBbcaI0Lnx7D"
-}, {
-  "tag" : "gag141",
-  "title" : "Die kurze Geschichte des Kokovorismus",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000413127578",
-  "url_spotify" : "https://open.spotify.com/episode/0Z3Q4EitG8hfh4dzOaPkN9"
-}, {
-  "tag" : "gag140",
-  "title" : "Eisbrecher für die Diplomatie – das Fußball-Länderspiel Sowjetunion gegen die BRD 1955",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000412551348",
-  "url_spotify" : "https://open.spotify.com/episode/5zM22GNYqBp4hnCBy9f5Uo"
-}, {
-  "tag" : "gag139",
-  "title" : "Als Voltaire die Lotterie knackte und steinreich wurde",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000412192106",
-  "url_spotify" : "https://open.spotify.com/episode/4qxLgkZAuOxKKwqlquQeYo"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000411916026",
-  "url_spotify" : "https://open.spotify.com/episode/3xKzOt38mOf2qeGtVdBxSy",
-  "title" : "Interview mit Historiker Jürgen Zimmerer über Kolonialgeschichte",
-  "tag" : "extra"
-}, {
-  "tag" : "gag138",
-  "title" : "Askari und die Kolonialgeschichte des Deutschen Reichs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000411669626",
-  "url_spotify" : "https://open.spotify.com/episode/2VLfXemiSqxOdztongvQho"
-}, {
-  "tag" : "gag137",
-  "title" : "Die Französisch-Britische Union",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000411014250",
-  "url_spotify" : "https://open.spotify.com/episode/274VGAWjCVzoIYo2d5vPDp"
-}, {
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000410850976",
-  "url_spotify" : "https://open.spotify.com/episode/7Atwlg4oByTGholJZLLXlJ",
-  "title" : "Die gesamte Führung durch den Jüdischen Friedhof Währing",
-  "tag" : "extra"
-}, {
-  "tag" : "gag136",
-  "title" : "Der Jüdische Friedhof Währing",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000410449590",
-  "url_spotify" : "https://open.spotify.com/episode/0u6ZwmNQVE1kSlbGBoQuyC"
-}, {
-  "tag" : "gag135",
-  "title" : "Adolf Loos",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000409797595",
-  "url_spotify" : "https://open.spotify.com/episode/4RX2W1Ml6z0OVwIiBddWbK"
-}, {
-  "tag" : "gag134",
-  "title" : "Eine kleine Geschichte des Kaiserschnitts anhand der Personen Jacob Nufer, James Barry und Margret Ann Bulkley",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000409132953",
-  "url_spotify" : "https://open.spotify.com/episode/4LBZskdx4nJpC0NWvOl7QL"
-}, {
-  "tag" : "gag133",
-  "title" : "Alexios Komnenos und der Erste Kreuzzug",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000408651056",
-  "url_spotify" : "https://open.spotify.com/episode/35xYH882tbbv2o0CA2l2o9"
-}, {
-  "tag" : "gag132",
-  "title" : "Gesche Gottfried, der Engel von Bremen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000408132127",
-  "url_spotify" : "https://open.spotify.com/episode/38H47XxnVO8YSwwM0rGe14"
-}, {
-  "tag" : "gag131",
-  "title" : "Strathclyde – ein (fast) vergessenes Königreich",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000407654746",
-  "url_spotify" : "https://open.spotify.com/episode/65vHsS9k0eosgg4PhpovUy"
-}, {
-  "tag" : "gag130",
-  "title" : "Alexander von Abonuteichos oder Wie ein Kult entsteht",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000407031552",
-  "url_spotify" : "https://open.spotify.com/episode/49AsgkN6GTXw5ZcjHhd0Mn"
-}, {
-  "tag" : "gag129",
-  "title" : "Die Entdeckung der Dinosaurier",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000406331495",
-  "url_spotify" : "https://open.spotify.com/episode/4Haz7sgcPJyyb2qRClHg3f"
-}, {
-  "tag" : "gag128",
-  "title" : "Crash at Crush",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000405239180",
-  "url_spotify" : "https://open.spotify.com/episode/4ygYmihhhgPzDm5wGYT1BK"
-}, {
-  "tag" : "gag127",
-  "title" : "Struensee – Aufstieg und Fall eines Arztes, der (für kurze Zeit) zum dänischen Regenten wurde",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000404146589",
-  "url_spotify" : "https://open.spotify.com/episode/29d5XY1lw5t2vWSOPIfp29"
-}, {
-  "tag" : "gag126",
-  "title" : "Für immer im Eis – die Franklin Expedition",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000403212378",
-  "url_spotify" : "https://open.spotify.com/episode/5e0y9IoQ5pd3k2NVVQPREF"
-}, {
-  "tag" : "gag125",
-  "title" : "Republik Fredonia",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000402295313",
-  "url_spotify" : "https://open.spotify.com/episode/6dnFW9f1FrGXVdEbAtXOOW"
-}, {
-  "tag" : "gag124",
-  "title" : "Eine kleine Geschichte des Chinese Restaurant Syndroms",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000401670816",
-  "url_spotify" : "https://open.spotify.com/episode/0q7nTK3vn4KNdxZc5BXj4o"
-}, {
-  "tag" : "gag123",
-  "title" : "Christian Gottlieb Prieber – Aussteiger, Renegade und beinahe vergessener Utopist",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000401118688",
-  "url_spotify" : "https://open.spotify.com/episode/4QbToGe3VWy7q0fgYWozw6"
-}, {
-  "tag" : "gag122",
-  "title" : "Die Belagerung von Masada",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000400584272",
-  "url_spotify" : "https://open.spotify.com/episode/0PzBVeyiuTgRcM6ppg0laW"
-}, {
-  "tag" : "gag121",
-  "title" : "Leopardenmorde und Leopardenmenschen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000400043163",
-  "url_spotify" : "https://open.spotify.com/episode/7kKxznbYoeehz6duoj5qcH"
-}, {
-  "tag" : "gag120",
-  "title" : "Die Rückkehr des Martin Guerre",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000399513604",
-  "url_spotify" : "https://open.spotify.com/episode/4tgtmIJDl4vpZxJ9bPUeug"
-}, {
-  "tag" : "gag119",
-  "title" : "Die NS-Thingbewegung - Thingstätten und Thingspiele",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000398978353",
-  "url_spotify" : "https://open.spotify.com/episode/1VB7hocOnWIMnBpDuZyKFG"
-}, {
-  "tag" : "gag118",
-  "title" : "Ein Werwolf in Livland",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000398482816",
-  "url_spotify" : "https://open.spotify.com/episode/6B0Zki8ejykxRiYActHEfL"
-}, {
-  "tag" : "gag117",
-  "title" : "Tunix, Tuwat und die Entstehung des Chaos Computer Clubs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000397865041",
-  "url_spotify" : "https://open.spotify.com/episode/19JOuGadTlRlmQQiUkyJg4"
-}, {
-  "tag" : "gag116",
-  "title" : "Über Basken, Wale und ein Massaker auf Island",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000397213121",
-  "url_spotify" : "https://open.spotify.com/episode/2oijaxCGn3RI0dPuJCXPIw"
-}, {
-  "tag" : "gag115",
-  "title" : "Eine kurze Geschichte der Hanse",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000396512110",
-  "url_spotify" : "https://open.spotify.com/episode/2Zqj4mNgPRY2OATuN624Q0"
-}, {
-  "tag" : "gag114",
-  "title" : "Gerhard Zucker und sein Raketentraum",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000395406934",
-  "url_spotify" : "https://open.spotify.com/episode/4LrohfQExYe1KvgDQ5TW8X"
-}, {
-  "tag" : "gag113",
-  "title" : "Die Hep-Hep-Unruhen von 1819",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000395127378",
-  "url_spotify" : "https://open.spotify.com/episode/1Ag57emcetM0VP2H6nHpvH"
-}, {
-  "tag" : "gag112",
-  "title" : "Adele Spitzeder und die 'Dachauer Bank'",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000394831834",
-  "url_spotify" : "https://open.spotify.com/episode/7BH6zSd39SjrlU86xhdgoA"
-}, {
-  "tag" : "gag111",
-  "title" : "Die Anfänge des Esperanto",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000394557748",
-  "url_spotify" : "https://open.spotify.com/episode/5lNq6xvACGdDEirTFvdgTY"
-}, {
-  "tag" : "gag110",
-  "title" : "110, 112, 999, etc.",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000394273581",
-  "url_spotify" : "https://open.spotify.com/episode/7FboByt5Ka4n9gUfcMEw9N"
-}, {
-  "tag" : "gag109",
-  "title" : "Der Lotterieaufstand in Albanien",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393989509",
-  "url_spotify" : "https://open.spotify.com/episode/6K1ZC7FNxzXSPKz7BUgKT4"
-}, {
-  "tag" : "gag108",
-  "title" : "Der Paderborner Kaffeelärm",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393675793",
-  "url_spotify" : "https://open.spotify.com/episode/0K52P0WwyfVaFDqC44kO4A"
-}, {
-  "tag" : "gag107",
-  "title" : "Eine kurze Geschichte der Guillotine",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393336380",
-  "url_spotify" : "https://open.spotify.com/episode/0gUaw16rgtUsjnYBzTifwV"
-}, {
-  "tag" : "gag106",
-  "title" : "Das Darién-Projekt und seine Folgen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393059858",
-  "url_spotify" : "https://open.spotify.com/episode/2dkRNKqAB6LVqZGsKLgjEG"
-}, {
-  "tag" : "gag105",
-  "title" : "Skanderberg - Ein neuer Alexander und seine Bedeutung für die Geschichte Albaniens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000392769311",
-  "url_spotify" : "https://open.spotify.com/episode/3AFWN32zUunBBExVqjVKiG"
-}, {
-  "tag" : "gag104",
-  "title" : "Crécy - Chronik eines Versagens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000392482829",
-  "url_spotify" : "https://open.spotify.com/episode/0hcUQ7KLmOvCIT8547IRmu"
-}, {
-  "tag" : "gag103",
-  "title" : "Demoskopie - eine kurze Geschichte der (politischen) Meinungsforschung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000392200591",
-  "url_spotify" : "https://open.spotify.com/episode/0PtVIHp9roLDN04XXIlO5e"
-}, {
-  "tag" : "gag102",
-  "title" : "Ein Picknick, das die Welt veränderte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391906949",
-  "url_spotify" : "https://open.spotify.com/episode/4vXMrFLnYQtiFtB4VkODsn"
-}, {
-  "tag" : "gag101",
-  "title" : "Leon Theremin - Was die Anfänge der elektronischen Musik mit Überwachungstechniken zu tun haben",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391634414",
-  "url_spotify" : "https://open.spotify.com/episode/4Wu2EjiZXiiaMU9eiw8Yqr"
-}, {
-  "tag" : "gag100",
-  "title" : "Der Fall der 'Mignonette' und seine Folgen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391371034",
-  "url_spotify" : "https://open.spotify.com/episode/7zYCafqO58iWoLugjzcSxw"
-}, {
-  "tag" : "gag99",
-  "title" : "Ignaz Semmelweis und die Bekämpfung des Kinderbettfiebers",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391108108",
-  "url_spotify" : "https://open.spotify.com/episode/1LJSNilwfXltmVZeYvp3rl"
-}, {
-  "tag" : "gag98",
-  "title" : "Über Schoßhunde und gierige Affen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390832808",
-  "url_spotify" : "https://open.spotify.com/episode/2QzvA5M6eSznw0fpoc5M7U"
-}, {
-  "tag" : "gag97",
-  "title" : "Neutral-Moresnet - Ein Niemandsland mitten in Europa",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390573702",
-  "url_spotify" : "https://open.spotify.com/episode/468ro0imwh6SDTMqBOUhcK"
-}, {
-  "tag" : "gag96",
-  "title" : "Von der Entstehung des Croissants und anderen kulinarischen Mythen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390368953",
-  "url_spotify" : "https://open.spotify.com/episode/4fiuElrnuiZSHWyFGFLXqM"
-}, {
-  "tag" : "gag95",
-  "title" : "Der Aufstieg des Jakob Fugger",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390055312",
-  "url_spotify" : "https://open.spotify.com/episode/5GnPKIQUIEFeviWKICACdf"
-}, {
-  "tag" : "gag94",
-  "title" : "Wer zitter nicht vor den Mohocks?",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000389814986",
-  "url_spotify" : "https://open.spotify.com/episode/3OQ2iq4EQc4cMbCp0Kn5he"
-}, {
-  "tag" : "gag93",
-  "title" : "Das Geheimnis des Lebens - Wie es zur Entdeckung der Doppelhelix kam",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000389551654",
-  "url_spotify" : "https://open.spotify.com/episode/79RGe9UIQSOw8Q8msjKLkf"
-}, {
-  "tag" : "gag92",
-  "title" : "Die Geschichte der Typhoid Mary",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000389275925",
-  "url_spotify" : "https://open.spotify.com/episode/4nBfBgw3EScKx7m4CqQvJj"
-}, {
-  "tag" : "gag91",
-  "title" : "Jan van Eyck - Der König unter den Malern und die Erfindung des Gemäldes",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000388295335",
-  "url_spotify" : "https://open.spotify.com/episode/3nupJ8jAKOBQdcdOjolALg"
-}, {
-  "tag" : "gag90",
-  "title" : "Aufstieg und Fall des Roger Casement",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000386549733",
-  "url_spotify" : "https://open.spotify.com/episode/6uO4msqtDmBm6Wkw4IP3kh"
-}, {
-  "tag" : "gag89",
-  "title" : "Seelenkonskription - die Anfänge der modernen Volkszählungen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000386385230",
-  "url_spotify" : "https://open.spotify.com/episode/2GqFnonR6sTTg14w9f9eiz"
-}, {
-  "tag" : "gag88",
-  "title" : "Von der Tanzwut und ihrer (wahrscheinlichen) Ursache",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000386109986",
-  "url_spotify" : "https://open.spotify.com/episode/5GG02QnjGbLA5CbsFQEYYY"
-}, {
-  "tag" : "gag87",
-  "title" : "Die Einführung von Freigeld und das Wunder von Wörgl",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385867963",
-  "url_spotify" : "https://open.spotify.com/episode/5hFUgLcljk5jgTIW48Jq0H"
-}, {
-  "tag" : "gag86",
-  "title" : "Sabbatai Zwi - Der falsche Messias",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385624258",
-  "url_spotify" : "https://open.spotify.com/episode/2O0TN6l3XMcvPGfEffVfgx"
-}, {
-  "tag" : "gag85",
-  "title" : "Ein Arm, ein Hai, ein Kriminalfall",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385388548",
-  "url_spotify" : "https://open.spotify.com/episode/0IVcUOqpO8gdRui1TZVid2"
-}, {
-  "tag" : "gag84",
-  "title" : "Eine kleine Geschichte des Klimas und des Klimawandels",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385153953",
-  "url_spotify" : "https://open.spotify.com/episode/1LFYZrfx8wccEjTEfJhBNa"
-}, {
-  "tag" : "gag83",
-  "title" : "100 Jahre vor der Reformation - Jan Hus und die Hussitenkriege",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384894569",
-  "url_spotify" : "https://open.spotify.com/episode/1sVRLs1J9M5KOjeqalH0ew"
-}, {
-  "tag" : "gag82",
-  "title" : "Victor Gruen und die Erfindung des Einkaufszentrums",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384652927",
-  "url_spotify" : "https://open.spotify.com/episode/6k5MyhZflO7WFtWVBYfY9y"
-}, {
-  "tag" : "gag81",
-  "title" : "Eine kurze Geschichte des Essbestecks (aber ohne Löffel)",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384405149",
-  "url_spotify" : "https://open.spotify.com/episode/4l2j17NMRk5ARzBBfXcNBn"
-}, {
-  "tag" : "gag80",
-  "title" : "Eine Kirche auf dem Dachboden - Reformation und das Goldene Zeitalter in den Niederlanden",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384136524",
-  "url_spotify" : "https://open.spotify.com/episode/4gH9GqNidBU2i3qmMVNkQD"
-}, {
-  "tag" : "gag79",
-  "title" : "Das Rolandslied - über Heldentaten, Karl den Großen und Kreuzzugpropaganda",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000383268304",
-  "url_spotify" : "https://open.spotify.com/episode/4vhSVl2ksQShTMmBicbBsF"
-}, {
-  "tag" : "gag78",
-  "title" : "Eine kurze Geschichte der Sommerzeit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382960991",
-  "url_spotify" : "https://open.spotify.com/episode/4g9YsUJ6p0YjKAKMufl4Av"
-}, {
-  "tag" : "gag77",
-  "title" : "Der Augsburger Kalenderstreit: Folgen eines tatsächlichen Zeitsprungs",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382660953",
-  "url_spotify" : "https://open.spotify.com/episode/3GlAh2eIIxeSDs14E6kACK"
-}, {
-  "tag" : "gag76",
-  "title" : "Holdouts - Japans vergessene Soldaten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382352420",
-  "url_spotify" : "https://open.spotify.com/episode/5W5s6cr971joBMVk4wsJGy"
-}, {
-  "tag" : "gag75",
-  "title" : "Sobhuza II., König von Swaziland",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382049102",
-  "url_spotify" : "https://open.spotify.com/episode/7dmnWLCRuFvjNzouKx5a2n"
-}, {
-  "tag" : "gag74",
-  "title" : "Die Bonnot-Bande und die Erfindung des Fluchtautos",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000381751312",
-  "url_spotify" : "https://open.spotify.com/episode/6GZkkxOTMmDoryaq6Wi5uQ"
-}, {
-  "tag" : "gag73",
-  "title" : "Ludwig XIV. und seine pikante Operation",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000381245027",
-  "url_spotify" : "https://open.spotify.com/episode/3lPJcz6bnmPzBw2AsL3gnB"
-}, {
-  "tag" : "gag72",
-  "title" : "Phantominseln",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380961719",
-  "url_spotify" : "https://open.spotify.com/episode/2p9X8ZWXwsvmVRhpFd0s6b"
-}, {
-  "tag" : "gag71",
-  "title" : "Wie die Kartoffel nach Europa kam (und alles veränderte)",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380668083",
-  "url_spotify" : "https://open.spotify.com/episode/0HZ3M389Q7riT5kOnqviYg"
-}, {
-  "tag" : "gag70",
-  "title" : "Die Würzburger Lügensteine",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380394299",
-  "url_spotify" : "https://open.spotify.com/episode/0KOIu4vHxSlrRiAroa9J1e"
-}, {
-  "tag" : "gag69",
-  "title" : "Die Boston Melasse Katastrophe",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380126837",
-  "url_spotify" : "https://open.spotify.com/episode/7f8q2497JfN88U3Y7nLiEH"
-}, {
-  "tag" : "gag68",
-  "title" : "Eine ganz kleine Geschichte der Mikroskopie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379845284",
-  "url_spotify" : "https://open.spotify.com/episode/62mjsecx5Av3rdYKm8a0Du"
-}, {
-  "tag" : "gag67",
-  "title" : "Palladio, der erfolgreichste Architekt aller Zeiten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379630652",
-  "url_spotify" : "https://open.spotify.com/episode/0RiMr1rhC42ICD8Ox1ooPB"
-}, {
-  "tag" : "gag66",
-  "title" : "Der Aufstieg Hamburgs- Fake it 'til you make it",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379398801",
-  "url_spotify" : "https://open.spotify.com/episode/4PDp0DZl0AlqrXQEYv5RI3"
-}, {
-  "tag" : "gag65",
-  "title" : "Die Erfindung des diamantenen Verlobungsrings",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379203346",
-  "url_spotify" : "https://open.spotify.com/episode/2cgTduXwfUeaJVzcVEVsBb"
-}, {
-  "tag" : "gag64",
-  "title" : "Paul Dirac und die Schönheit der Mathematik",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378982662",
-  "url_spotify" : "https://open.spotify.com/episode/2dc9AUzVeH7Xup0k6KrRpo"
-}, {
-  "tag" : "gag63",
-  "title" : "Konstantin und die Janitscharen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378717815",
-  "url_spotify" : "https://open.spotify.com/episode/2s7KEZmGwDSE8simg0wgAm"
-}, {
-  "tag" : "gag62",
-  "title" : "Eine kurze Geschichte der Rollschuhe und des Rollschuhfahrens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378437955",
-  "url_spotify" : "https://open.spotify.com/episode/5Dv7XJiEjS0v0JWxqvvB01"
-}, {
-  "tag" : "gag61",
-  "title" : "Die niederländische 'Tulpenmanie' (und warum sie gar nicht so schlimm war)",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378200683",
-  "url_spotify" : "https://open.spotify.com/episode/2mdw5slqoOUiQ2qCJxWJfN"
-}, {
-  "tag" : "gag60",
-  "title" : "Wie das Essengehen erfunden wurde",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377932182",
-  "url_spotify" : "https://open.spotify.com/episode/5Fg96tVbHxEwLxH3YNj75A"
-}, {
-  "tag" : "gag59",
-  "title" : "The Lost Colony",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377684758",
-  "url_spotify" : "https://open.spotify.com/episode/0fdYpNwTWATYoCzKasdfwE"
-}, {
-  "tag" : "gag58",
-  "title" : "Londoner Kutschenstreit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377431298",
-  "url_spotify" : "https://open.spotify.com/episode/57GHnY257TIXPYQ1rkLHGq"
-}, {
-  "tag" : "gag57",
-  "title" : "Von Grabtüchern, Knochen und wieder mal Venedig",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377156069",
-  "url_spotify" : "https://open.spotify.com/episode/4IFjipZWkWjaUyXoEhujRM"
-}, {
-  "tag" : "gag56",
-  "title" : "Piggly Wiggly und die Geschichte des Supermarkts",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000376858721",
-  "url_spotify" : "https://open.spotify.com/episode/4y4EKtR3q0LTs16aM2hTkL"
-}, {
-  "tag" : "gag55",
-  "title" : "Der letzte Kammerdiener des alten Kaisers",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000376538016",
-  "url_spotify" : "https://open.spotify.com/episode/3mqHGEYQdnor31jmkAg054"
-}, {
-  "tag" : "gag54",
-  "title" : "Die erste Rektorin einer deutschen Universität",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000376235801",
-  "url_spotify" : "https://open.spotify.com/episode/1fIiWyfEkK9E9yoq5e4yTc"
-}, {
-  "tag" : "gag53",
-  "title" : "Ein Verrat und ein langer Strich auf der Berliner Mauer",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375932154",
-  "url_spotify" : "https://open.spotify.com/episode/5SapwNpGIpWbXN5m3tcF28"
-}, {
-  "tag" : "gag52",
-  "title" : "Die Geschichte der Annie Londonderry, 'New Woman' und Fahrradweltreisende",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375561576",
-  "url_spotify" : "https://open.spotify.com/episode/6TS6XpIbA1bcyyKpKBBhoh"
-}, {
-  "tag" : "gag51",
-  "title" : "Eine kurze Geschichte der Rhythmologie und der Erforschung des Herzens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375305415",
-  "url_spotify" : "https://open.spotify.com/episode/2M9A42QccAi1wSEUeWHQpV"
-}, {
-  "tag" : "gag50",
-  "title" : "Ossian, ein altgälisches Epos wie keines davor",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375026008",
-  "url_spotify" : "https://open.spotify.com/episode/1y3v0w0AKfa7SdO3KMG1Mc"
-}, {
-  "tag" : "gag49",
-  "title" : "Der 'Dig Tree' und die erste Durchquerung Australiens",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000374763865",
-  "url_spotify" : "https://open.spotify.com/episode/7peM2oyLO8ZKY3u4WpsZIT"
-}, {
-  "tag" : "gag48",
-  "title" : "George Ansons katastrophale Expedition",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000374536825",
-  "url_spotify" : "https://open.spotify.com/episode/2TkSGKH5blxHXQ01aAn0eW"
-}, {
-  "tag" : "gag47",
-  "title" : "Die Schwabenkinder und ihre Geschichte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000374229545",
-  "url_spotify" : "https://open.spotify.com/episode/6dQFSMSiSnDXPgUYpiXJ2k"
-}, {
-  "tag" : "gag46",
-  "title" : "Aufstieg und Fall der Republik Ragusa",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000373904462",
-  "url_spotify" : "https://open.spotify.com/episode/0ktlpREDhRYFJFNMXtuvGW"
-}, {
-  "tag" : "gag45",
-  "title" : "Zwentendorf - Das sicherste Kernkraftwerk der Welt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000373601309",
-  "url_spotify" : "https://open.spotify.com/episode/0MQVQ0SHPNQ15sN2KhbM7x"
-}, {
-  "tag" : "gag44",
-  "title" : "Eine kurze Geschichte der Süßigkeiten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000373059040",
-  "url_spotify" : "https://open.spotify.com/episode/0GEWYdE9J1XrNHsXBQoGhJ"
-}, {
-  "tag" : "gag43",
-  "title" : "Josef Eisemann, Seiltänzer in Wien",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000372823671",
-  "url_spotify" : "https://open.spotify.com/episode/2NZOCeCcJl438EM7gCSx4N"
-}, {
-  "tag" : "gag42",
-  "title" : "The City of Roses - Ein Rosengarten für Portland",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000372341809",
-  "url_spotify" : "https://open.spotify.com/episode/17hMeVKZgYymE7anl1CjCj"
-}, {
-  "tag" : "gag41",
-  "title" : "Der Wiener Kreis und die Ermordung von Moritz Schlick",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000371884972",
-  "url_spotify" : "https://open.spotify.com/episode/5zgYBqbxtv4rafdWAEglfX"
-}, {
-  "tag" : "gag40",
-  "title" : "Über den Ursprung der Seidenstraße",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000371475561",
-  "url_spotify" : "https://open.spotify.com/episode/7o7nnbR9xKSNFpCLAZe394"
-}, {
-  "tag" : "gag39",
-  "title" : "Die Legion Erzengel Michael und Corneliu Codreanu",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000371062610",
-  "url_spotify" : "https://open.spotify.com/episode/4GwfbJ4dH7ATHkqHd2BDCD"
-}, {
-  "tag" : "gag38",
-  "title" : "Eine kurze Geschichte der Leibeigenschaft",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000370597666",
-  "url_spotify" : "https://open.spotify.com/episode/35Bb45qDhB3ABbjGJ1Z7xO"
-}, {
-  "tag" : "gag37",
-  "title" : "Eine Reise um die Welt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000370126493",
-  "url_spotify" : "https://open.spotify.com/episode/69SqnOPmWsdYnB4HHUMTYk"
-}, {
-  "tag" : "gag36",
-  "title" : "Eine sehr kurze Geschichte des Deodorants",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000369653738",
-  "url_spotify" : "https://open.spotify.com/episode/1dYCRs5hj0vou7u8w67Muh"
-}, {
-  "tag" : "gag35",
-  "title" : "Magia Posthuma - Vampirismus in den Zeiten der Aufklärung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000369194979",
-  "url_spotify" : "https://open.spotify.com/episode/569BgwkAlPOQNu4KbIIJJt"
-}, {
-  "tag" : "gag34",
-  "title" : "Tee, Silber und Rauschmittel",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000368858130",
-  "url_spotify" : "https://open.spotify.com/episode/3aKv2pBWWfcSVMjpqVAtcj"
-}, {
-  "tag" : "gag33",
-  "title" : "Curta - eine Rechenmaschine und ihre Geschichte",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000368309600",
-  "url_spotify" : "https://open.spotify.com/episode/5ojlO6FWbA4C20uKBbU8yp"
-}, {
-  "tag" : "gag32",
-  "title" : "Henry Gunther",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000367955989",
-  "url_spotify" : "https://open.spotify.com/episode/0ziTikri0S4UTavurCr8XG"
-}, {
-  "tag" : "gag31",
-  "title" : "Blitzkrieg im Fußballstadion",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000367480748",
-  "url_spotify" : "https://open.spotify.com/episode/4FrToSJ13FiZwC7ytHLk7e"
-}, {
-  "tag" : "gag30",
-  "title" : "Wie die Zeit zu unserer wurde",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000367043045",
-  "url_spotify" : "https://open.spotify.com/episode/3Le6OFVfsm3F9bgD2l6L9t"
-}, {
-  "tag" : "gag29",
-  "title" : "Ein Müller in den Fängen der Inquisition",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000366607746",
-  "url_spotify" : "https://open.spotify.com/episode/36Ans1qAdipWgZsPzFYG4t"
-}, {
-  "tag" : "gag28",
-  "title" : "Von Appenzellern, Bregenzern und einer Frau names Guta",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000366163176",
-  "url_spotify" : "https://open.spotify.com/episode/5yAE4vQZqYSIvwi7PGNYdP"
-}, {
-  "tag" : "gag27",
-  "title" : "Die Rote Zora und ihre Vorfahren",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000365785209",
-  "url_spotify" : "https://open.spotify.com/episode/7bTAEmD4kC0rXMC4Z9QOcx"
-}, {
-  "tag" : "gag26",
-  "title" : "Wie der Champagner zu seinen Bläschen kam",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000365199724",
-  "url_spotify" : "https://open.spotify.com/episode/4wdfjAlHgvM5eo7ns867qr"
-}, {
-  "tag" : "gag25",
-  "title" : "Eine kaiserliche Bibliothek des Menschengeschlechts",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000364783840",
-  "url_spotify" : "https://open.spotify.com/episode/2mBnZqrkj3enlRDhshMBQ3"
-}, {
-  "tag" : "gag24",
-  "title" : "A French Connection, zum Scheitern verurteilt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000364342418",
-  "url_spotify" : "https://open.spotify.com/episode/60oDLT7NGLEoDUKTm0tkvq"
-}, {
-  "tag" : "gag23",
-  "title" : "Ziemlich beste Feindschaft",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000363885036",
-  "url_spotify" : "https://open.spotify.com/episode/0BOZqPVfdzHB0RX8qwcAKn"
-}, {
-  "tag" : "gag22",
-  "title" : "Vom Goldjungen zum Staatsgefangenen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000363400232",
-  "url_spotify" : "https://open.spotify.com/episode/55tuPyFsS55oEJvW02II82"
-}, {
-  "tag" : "gag21",
-  "title" : "Von der Erfindung der Einbauküche",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000362950918",
-  "url_spotify" : "https://open.spotify.com/episode/26OMG7KLf5vD1jYHY7gvTO"
-}, {
-  "tag" : "gag20",
-  "title" : "Von Drachenknochen und Schildkrötenorakeln",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000362387773",
-  "url_spotify" : "https://open.spotify.com/episode/2wZr4n7gJxw0s3IsUsP1ZZ"
-}, {
-  "tag" : "gag19",
-  "title" : "Wenn ein Wissenschaftler an Drachen glaubt",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000361702515",
-  "url_spotify" : "https://open.spotify.com/episode/1Ej4mZ8G9XGsUSOE6iT7M9"
-}, {
-  "tag" : "gag18",
-  "title" : "Wie Russland den Bart verlor",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000361255781",
-  "url_spotify" : "https://open.spotify.com/episode/2HcUi5B4wzj2vuaMnmbV99"
-}, {
-  "tag" : "gag17",
-  "title" : "Eine Urkunde, ein Zeltlager und eine Fälschung",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000360826303",
-  "url_spotify" : "https://open.spotify.com/episode/14jBSIe5bjsbUafniFoCin"
-}, {
-  "tag" : "gag16",
-  "title" : "Ton, Steine, Scherben oder wie Rom sich einen achten Hügel baute",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000360420675",
-  "url_spotify" : "https://open.spotify.com/episode/0hvwzNXrxApvi5sTZfnS8F"
-}, {
-  "tag" : "gag15",
-  "title" : "Das Mailüfterl",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000360006419",
-  "url_spotify" : "https://open.spotify.com/episode/2Yk2X5TrOBDDlwpkOrUTVY"
-}, {
-  "tag" : "gag14",
-  "title" : "Ein englisches Atlantis",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000359696165",
-  "url_spotify" : "https://open.spotify.com/episode/5bqwI3qiqMswvWHgp0INYv"
-}, {
-  "tag" : "gag13",
-  "title" : "Ein Spionagefall erschüttert die Habsburger Monarchie",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000359300003",
-  "url_spotify" : "https://open.spotify.com/episode/2v6tqvI7CdTJa9F02gtYjB"
-}, {
-  "tag" : "gag12",
-  "title" : "Ein Kaiser, ein Gott, viele Todesfälle",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000358875914",
-  "url_spotify" : "https://open.spotify.com/episode/2RSruQHsfNLa6yKdtMiDXF"
-}, {
-  "tag" : "gag11",
-  "title" : "Von Kindern und Kegeln",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000358457200",
-  "url_spotify" : "https://open.spotify.com/episode/3irhNgBuWH7YtFT6MPNjXC"
-}, {
-  "tag" : "gag10",
-  "title" : "Craigslist in der Frühen Neuzeit",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000358051702",
-  "url_spotify" : "https://open.spotify.com/episode/4vqNH3KZDEUkIcG0izbMgn"
-}, {
-  "tag" : "gag9",
-  "title" : "Wer den englischen Parlamentsbrand auf dem Kerbholz hat",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000357623768",
-  "url_spotify" : "https://open.spotify.com/episode/2hecJlymUeMQlToqtBgBuz"
-}, {
-  "tag" : "gag8",
-  "title" : "Herr der Fliegen",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000357222331",
-  "url_spotify" : "https://open.spotify.com/episode/4Dfo4Dib61XYhRc40hZydl"
-}, {
-  "tag" : "gag7",
-  "title" : "Geteilte Habsburger",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000356686509",
-  "url_spotify" : "https://open.spotify.com/episode/4B3UCglSP0F1GJuJZDDdH3"
-}, {
-  "tag" : "gag6",
-  "title" : "Ada und die Pferdewetten",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000356103093",
-  "url_spotify" : "https://open.spotify.com/episode/4nS64s7eiFYeXiYiCK24gB"
-}, {
-  "tag" : "gag5",
-  "title" : "Lernen Sie Geschichte!",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000355466179",
-  "url_spotify" : "https://open.spotify.com/episode/5K0LHcD6nvsb4ZUtTxBrQJ"
-}, {
-  "tag" : "gag4",
-  "title" : "Wellingtons Rache, oder: Ein Bein für ein Königreich",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000354819402",
-  "url_spotify" : "https://open.spotify.com/episode/4AOG0wWu7sdF5ap7yHhmsy"
-}, {
-  "tag" : "gag3",
-  "title" : "Fitness-Parcours für den Pharao",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000354603876",
-  "url_spotify" : "https://open.spotify.com/episode/1k2l2ZOyUgqdxkIPVuDeC9"
-}, {
-  "tag" : "gag2",
-  "title" : "Tatortschau mit Wiedererkennungswert",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000354056193",
-  "url_spotify" : "https://open.spotify.com/episode/2TFcFH2nTYXMX7od8sw3cp"
-}, {
-  "tag" : "gag1",
-  "title" : "Vier Langobarden-Könige und ein Trinkbecher",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000353743751",
-  "url_spotify" : "https://open.spotify.com/episode/3RQ14uPgwzFjCxXhahKrTH"
-}, {
-  "title" : "Bounty, Brotfrucht und die Rum-Rebellion",
-  "tag" : "gag483",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000681469728",
-  "url_spotify" : "https://open.spotify.com/episode/2Vowdc9tHElrpqW6jCx0qU"
-}, {
-  "title" : "Eine kleine Geschichte des Experiments",
-  "tag" : "gag485",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000683078150",
-  "url_spotify" : "https://open.spotify.com/episode/2Wdh6PLpmvqS8YVWguEYvT"
-}, {
-  "title" : "Kurze Geschichte der Tomate",
-  "tag" : "gag487",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000684919010",
-  "url_spotify" : "https://open.spotify.com/episode/2f8eDt5joqvkAjCEzxDwdv"
-}, {
-  "title" : "Ein Konzil, ein Papst und ein Bücherjäger",
-  "tag" : "gag489",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000689031048",
-  "url_spotify" : "https://open.spotify.com/episode/5OJEu5sJ4lQ1r4TshKbl0K"
-}, {
-  "title" : "Über die Große Welle, Planetenkonstellationen und Kugelschreiber",
-  "tag" : "fgag19",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000692788646",
-  "url_spotify" : "https://open.spotify.com/episode/0S2N5l9LYpQe8Zdq6LWOUD"
-}, {
-  "title" : "Eine kleine Geschichte der Hygiene",
-  "tag" : "gag492",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000695823104",
-  "url_spotify" : "https://open.spotify.com/episode/6Io0vbLm5CJ5Bgi2ey2xD1"
-}, {
-  "title" : "Der Serumlauf nach Nome",
-  "tag" : "gag494",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000698729224",
-  "url_spotify" : "https://open.spotify.com/episode/4zokx4nhkZ0UqqALLWKmld"
-}, {
-  "title" : "Sophie Germain",
-  "tag" : "gag496",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000700764655",
-  "url_spotify" : "https://open.spotify.com/episode/0XQa8v1nzFv9KDzpGcz3Uj"
-}, {
-  "title" : "Eine kleine Geschichte des Grimoires",
-  "tag" : "gag498",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000702676526",
-  "url_spotify" : "https://open.spotify.com/episode/4yuX5UhGpk0RgBrZDf3cIM"
-}, {
-  "title" : "Kleine Geschichte eines Jubiläums",
-  "tag" : "gag500",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000704525719",
-  "url_spotify" : "https://open.spotify.com/episode/7lRPj7qgMRMyXqoHG6sXj9"
-}, {
-  "title" : "Die Fehde und Kohlhase",
-  "tag" : "gag502",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000706587611",
-  "url_spotify" : "https://open.spotify.com/episode/0kBiR2cDU17EI3VlgUp02V"
-}, {
-  "title" : "Ein Nashorn auf großer Tour",
-  "tag" : "gag504",
-  "url_apple_podcasts" : "https://podcasts.apple.com/de/podcast/id1044844618?i=1000709053343",
-  "url_spotify" : "https://open.spotify.com/episode/1JCYmjdCPrkcrntDtvJYLG"
-} ]
+[
+  {
+    "title": "William H. Mumler, Geisterfotograf",
+    "tag": "gag505",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000710093433",
+    "url_spotify": "https://open.spotify.com/episode/5OanQii9TMvgUjMBCqBa33"
+  },
+  {
+    "title": "Ein Nashorn auf großer Tour",
+    "tag": "gag504",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000709053343",
+    "url_spotify": "https://open.spotify.com/episode/1JCYmjdCPrkcrntDtvJYLG"
+  },
+  {
+    "title": "Die Schlacht bei Kadesch",
+    "tag": "gag503",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000708420848",
+    "url_spotify": "https://open.spotify.com/episode/7ubzOCUdeRKGqbgyMb6kTO"
+  },
+  {
+    "title": "Die Fehde und Kohlhase",
+    "tag": "gag502",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000706587611",
+    "url_spotify": "https://open.spotify.com/episode/0kBiR2cDU17EI3VlgUp02V"
+  },
+  {
+    "title": "Wie die Jeans entstand",
+    "tag": "gag501",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000705259164",
+    "url_spotify": "https://open.spotify.com/episode/4WnNgboTbMJ4UjGg36sv7n"
+  },
+  {
+    "title": "Kleine Geschichte eines Jubiläums",
+    "tag": "gag500",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000704525719",
+    "url_spotify": "https://open.spotify.com/episode/7lRPj7qgMRMyXqoHG6sXj9"
+  },
+  {
+    "title": "Die wendungsreiche Karriere eines deutschen Revolutionärs in den USA",
+    "tag": "gag499",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000703566297",
+    "url_spotify": "https://open.spotify.com/episode/7A5z3wlYSYzodLLIge6TdU"
+  },
+  {
+    "title": "Eine kleine Geschichte des Grimoires",
+    "tag": "gag498",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000702676526",
+    "url_spotify": "https://open.spotify.com/episode/4yuX5UhGpk0RgBrZDf3cIM"
+  },
+  {
+    "title": "Drais und die Laufmaschine",
+    "tag": "gag497",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000701734752",
+    "url_spotify": "https://open.spotify.com/episode/387dmYlSSmi5WUeKnmno2X"
+  },
+  {
+    "title": "Sophie Germain",
+    "tag": "gag496",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000700764655",
+    "url_spotify": "https://open.spotify.com/episode/0XQa8v1nzFv9KDzpGcz3Uj"
+  },
+  {
+    "title": "Das Bandoneon und der Tango",
+    "tag": "gag495",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000699708149",
+    "url_spotify": "https://open.spotify.com/episode/4JEP3nviQi5OzZjEmYdd83"
+  },
+  {
+    "title": "Der Serumlauf nach Nome",
+    "tag": "gag494",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000698729224",
+    "url_spotify": "https://open.spotify.com/episode/4zokx4nhkZ0UqqALLWKmld"
+  },
+  {
+    "title": "Kernspaltung und Schwerwasser-Sabotage",
+    "tag": "gag493",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000697649337",
+    "url_spotify": "https://open.spotify.com/episode/4cYBmGEXd9PyghDbAEq3Q9"
+  },
+  {
+    "title": "Eine kleine Geschichte der Hygiene",
+    "tag": "gag492",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000695823104",
+    "url_spotify": "https://open.spotify.com/episode/6Io0vbLm5CJ5Bgi2ey2xD1"
+  },
+  {
+    "title": "Die Dreyfus-Affäre",
+    "tag": "gag491",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000693716547",
+    "url_spotify": "https://open.spotify.com/episode/4w6cJaI1YCPxgy4dGsRPbW"
+  },
+  {
+    "title": "Über die Große Welle, Planetenkonstellationen und Kugelschreiber",
+    "tag": "fgag19",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000692788646",
+    "url_spotify": "https://open.spotify.com/episode/0S2N5l9LYpQe8Zdq6LWOUD"
+  },
+  {
+    "title": "Eunus und der erste Sklavenkrieg",
+    "tag": "gag490",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000691103614",
+    "url_spotify": "https://open.spotify.com/episode/4XZRoBAiqQZeS5HZ4JjfFm"
+  },
+  {
+    "title": "Ein Konzil, ein Papst und ein Bücherjäger",
+    "tag": "gag489",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000689031048",
+    "url_spotify": "https://open.spotify.com/episode/5OJEu5sJ4lQ1r4TshKbl0K"
+  },
+  {
+    "title": "Hokusai und die Große Welle",
+    "tag": "gag488",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000685848829",
+    "url_spotify": "https://open.spotify.com/episode/2qbnOfXhNDkgLD5LnIPppu"
+  },
+  {
+    "title": "Kurze Geschichte der Tomate",
+    "tag": "gag487",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000684919010",
+    "url_spotify": "https://open.spotify.com/episode/2f8eDt5joqvkAjCEzxDwdv"
+  },
+  {
+    "title": "Professor Porta und das Ende der Welt",
+    "tag": "gag486",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000683806667",
+    "url_spotify": "https://open.spotify.com/episode/7h5EfEpmXaBiIBEJFUtTOD"
+  },
+  {
+    "title": "Eine kleine Geschichte des Experiments",
+    "tag": "gag485",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000683078150",
+    "url_spotify": "https://open.spotify.com/episode/2Wdh6PLpmvqS8YVWguEYvT"
+  },
+  {
+    "title": "Emil Berliner und die Erfindung der Musikindustrie",
+    "tag": "gag484",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000682218521",
+    "url_spotify": "https://open.spotify.com/episode/2kC72lwL4qZQu5JlebpU43"
+  },
+  {
+    "title": "Bounty, Brotfrucht und die Rum-Rebellion",
+    "tag": "gag483",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000681469728",
+    "url_spotify": "https://open.spotify.com/episode/2Vowdc9tHElrpqW6jCx0qU"
+  },
+  {
+    "title": "Sarawak und die Dynastie der Weißen Rajahs",
+    "tag": "gag482",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000680709654",
+    "url_spotify": "https://open.spotify.com/episode/3pvxRGTplNCoAR2fRCwmJh"
+  },
+  {
+    "title": "Zwei Hochzeiten und zwei Todesfälle",
+    "tag": "gag481",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000679892820",
+    "url_spotify": "https://open.spotify.com/episode/27vj3Ilu0g9qnymIBvDH3H"
+  },
+  {
+    "title": "Kein Klecks – die Erfindung des Kugelschreibers",
+    "tag": "gag480",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000679071520",
+    "url_spotify": "https://open.spotify.com/episode/6RTwYDJ0VMCrhgOFnbwCYs"
+  },
+  {
+    "title": "Über einen, der alles wusste – Athanasius Kircher",
+    "tag": "gag479",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000678326005",
+    "url_spotify": "https://open.spotify.com/episode/3IogvYQfAuVscKXoJT9zBo"
+  },
+  {
+    "title": "Das Königreich Ryukyu",
+    "tag": "gag478",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000677459816",
+    "url_spotify": "https://open.spotify.com/episode/63OM4XFRSrLasinlEsexUv"
+  },
+  {
+    "title": "Über Lochkarten, Anzüge und die Faszination Alhambra",
+    "tag": "fgag18",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000677216728",
+    "url_spotify": "https://open.spotify.com/episode/5fhF9FxtGFgVwA8jkEUcsy"
+  },
+  {
+    "title": "Kleine Geschichte des Artensterbens",
+    "tag": "gag477",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000676694470",
+    "url_spotify": "https://open.spotify.com/episode/4ie7NZ0HSV5rVlvUTSx6Zn"
+  },
+  {
+    "title": "Boabdil und das Ende Granadas",
+    "tag": "gag476",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000675439410",
+    "url_spotify": "https://open.spotify.com/episode/0PiZi2pnwMditk64bF3uVs"
+  },
+  {
+    "title": "Eine kleine Geschichte des Anzugs",
+    "tag": "gag475",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000674876475",
+    "url_spotify": "https://open.spotify.com/episode/77YC7cSXdrBTt1PnIsiGp7"
+  },
+  {
+    "title": "Eine kleine Geschichte des Zeitreisens",
+    "tag": "gag474",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000673994096",
+    "url_spotify": "https://open.spotify.com/episode/7wuaIy5fSLwQniquyHbPAV"
+  },
+  {
+    "title": "Die Erfindung der Lochkarte",
+    "tag": "gag473",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000673214924",
+    "url_spotify": "https://open.spotify.com/episode/3BmgIb6IC9ZwqJKRRVbogS"
+  },
+  {
+    "title": "Das Sommerspecial",
+    "tag": "fgag17",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000672506772",
+    "url_spotify": "https://open.spotify.com/episode/08UIt04hIspLwspdL9mFDw"
+  },
+  {
+    "title": "Die Antoninische Pest",
+    "tag": "gag472",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000672137394",
+    "url_spotify": "https://open.spotify.com/episode/73yjOYL2ZT184InxCNCTyf"
+  },
+  {
+    "title": "Karl XII. und das Ende des Schwedischen Reichs",
+    "tag": "gag471",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000671433564",
+    "url_spotify": "https://open.spotify.com/episode/2I7mi0Mnb4OXGnXuxmWdtE"
+  },
+  {
+    "title": "Alexis Soyer – Koch, Innovator und Philanthrop",
+    "tag": "gag470",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000670526639",
+    "url_spotify": "https://open.spotify.com/episode/2jedkVa6e6VJvigS6npo58"
+  },
+  {
+    "title": "Diebstahl der Mona Lisa",
+    "tag": "gag469",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000669798113",
+    "url_spotify": "https://open.spotify.com/episode/0HBpdQoFZEg3OXYJDpY50K"
+  },
+  {
+    "title": "Arabia Felix oder Die Dänisch Arabische Expedition",
+    "tag": "gag468",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000669008245",
+    "url_spotify": "https://open.spotify.com/episode/5paOofOmVYIhUJpa2EKOB6"
+  },
+  {
+    "title": "Das Leben der Lucrezia Borgia",
+    "tag": "gag467",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000668218893",
+    "url_spotify": "https://open.spotify.com/episode/2E1BeVDi0CK3CAzjBjFLqD"
+  },
+  {
+    "title": "A chat with Dr. Emma Southon on 21 women who shaped Roman History",
+    "tag": "extra-AcwDESo2wwsRH",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000667777552",
+    "url_spotify": "https://open.spotify.com/episode/1pmwhJGaVYCFYIBWA5XLVb"
+  },
+  {
+    "title": "Julia Felix und das Ende Pompejis",
+    "tag": "gag466",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000666666516",
+    "url_spotify": "https://open.spotify.com/episode/7qPsODMyQhjTM12MfTvXU6"
+  },
+  {
+    "title": "Wie Aluminium entdeckt wurde",
+    "tag": "gag465",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000666044957",
+    "url_spotify": "https://open.spotify.com/episode/5yfmrAO9HipHJ3KhgY87Qv"
+  },
+  {
+    "title": "Die Entstehung des Central Parks",
+    "tag": "gag464",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000664810729",
+    "url_spotify": "https://open.spotify.com/episode/1XVg8frLjCARbokNY2vGiW"
+  },
+  {
+    "title": "Die Erfindung der Glühlampe",
+    "tag": "gag463",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000664461324",
+    "url_spotify": "https://open.spotify.com/episode/7ELvynYSs0Pr1945V6jxLC"
+  },
+  {
+    "title": "Die Schlacht an den Thermopylen oder Das erste letzte Gefecht der Geschichte",
+    "tag": "gag462",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000663791788",
+    "url_spotify": "https://open.spotify.com/episode/3bdWMbEpjWS1NcSmv4NAmY"
+  },
+  {
+    "title": "Das längste Autorennen der Welt",
+    "tag": "gag461",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000663130550",
+    "url_spotify": "https://open.spotify.com/episode/33cKv4aLWnfnRY3D79s6eK"
+  },
+  {
+    "title": "Lorenzo Da Ponte oder Wie ein Librettist entsteht",
+    "tag": "gag460",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000662404324",
+    "url_spotify": "https://open.spotify.com/episode/1n9dO3XyFPSjyFuYPACZST"
+  },
+  {
+    "title": "Eine Kaiserin für Brasilien",
+    "tag": "gag459",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000661700355",
+    "url_spotify": "https://open.spotify.com/episode/2IXlpgFsBC8A8YMqy7gNvl"
+  },
+  {
+    "title": "Über Toilettengang im All, die Métis-Fiddle und Belletristik zu berühmten Hirnen",
+    "tag": "fgag16",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000661326636",
+    "url_spotify": "https://open.spotify.com/episode/0PLFl9jf7mqDmfRTJ0KbNQ"
+  },
+  {
+    "title": "Wie wir die Nacht zum Tag machten",
+    "tag": "gag458",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000660832286",
+    "url_spotify": "https://open.spotify.com/episode/0UEAaIdc6S3nVjmCgppnWR"
+  },
+  {
+    "title": "Die Ermordung des Burgunderherzogs",
+    "tag": "gag457",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000660164683",
+    "url_spotify": "https://open.spotify.com/episode/1FupzpcOMhjnB8sk7OeSa2"
+  },
+  {
+    "title": "Bierkriege – Tatort Geschichte Crossover",
+    "tag": "gag456",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000659437681",
+    "url_spotify": "https://open.spotify.com/episode/6mSXCvsrhPsLLKBuHp0GeC"
+  },
+  {
+    "title": "Das Unternehmen Pastorius",
+    "tag": "gag455",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000658601659",
+    "url_spotify": "https://open.spotify.com/episode/7ykXCRHoRDBhkEBwkMSpXg"
+  },
+  {
+    "title": "Geniale Gehirne",
+    "tag": "gag454",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000657651210",
+    "url_spotify": "https://open.spotify.com/episode/670NGn5lHi6QDiKerasnWG"
+  },
+  {
+    "title": "Pemmikan und der Pelzhandel in Nordamerika",
+    "tag": "gag453",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000657038476",
+    "url_spotify": "https://open.spotify.com/episode/2XoZum7eNrcfLCJEqsIVZE"
+  },
+  {
+    "title": "Der GAG-Effekt",
+    "tag": "fgag15",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000656758667",
+    "url_spotify": "https://open.spotify.com/episode/3v7i1n24EPvDgqcupmXCEM"
+  },
+  {
+    "title": "Der erste Mensch im All",
+    "tag": "gag452",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000656366515",
+    "url_spotify": "https://open.spotify.com/episode/2b15qaraQH7Eq8UK9K24AU"
+  },
+  {
+    "title": "Eine kleine Geschichte der verlorenen Bücher",
+    "tag": "gag451",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000655558002",
+    "url_spotify": "https://open.spotify.com/episode/0QkfKByAMNwlkkWDslYBsf"
+  },
+  {
+    "title": "Tudor und der Eishandel",
+    "tag": "gag450",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000654795741",
+    "url_spotify": "https://open.spotify.com/episode/1ov1eG8on20AVCq6eOyfKA"
+  },
+  {
+    "title": "Die Wiederentdeckung der Moriori",
+    "tag": "gag449",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000653914480",
+    "url_spotify": "https://open.spotify.com/episode/4Wmtb61eQ1StjNXTjiZ5Fi"
+  },
+  {
+    "title": "Die Phenol-Verschwörung",
+    "tag": "gag448",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000653384492",
+    "url_spotify": "https://open.spotify.com/episode/7MqpioF3kBryzQhshttK7B"
+  },
+  {
+    "title": "Christina, Hans und Heinrich oder Wie ein Gemälde entsteht",
+    "tag": "gag447",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000652601553",
+    "url_spotify": "https://open.spotify.com/episode/3AqXpXernJq9n7BQNznFcn"
+  },
+  {
+    "title": "Ein Duft aus Köln",
+    "tag": "gag446",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000651869680",
+    "url_spotify": "https://open.spotify.com/episode/75hlZvWmz2oIMNnFPZRAqn"
+  },
+  {
+    "title": "Über Knopflöcher, Propaganda im frühen Perserreich und zu hohe Fahrräder",
+    "tag": "fgag14",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000651666293",
+    "url_spotify": "https://open.spotify.com/episode/5WDKeG9fD0sreNbDGUafFL"
+  },
+  {
+    "title": "Alexandra David-Néel",
+    "tag": "gag445",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000651207304",
+    "url_spotify": "https://open.spotify.com/episode/18cEudoxSb717DoA1VFkZ1"
+  },
+  {
+    "title": "Die Erfindung von Heroin und Aspirin",
+    "tag": "gag444",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000650484872",
+    "url_spotify": "https://open.spotify.com/episode/1equTrRAwUHIrssXg1iLRn"
+  },
+  {
+    "title": "J.S. Bach oder Wie sich ein Komponist den Lebensunterhalt verdient",
+    "tag": "gag443",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000649694604",
+    "url_spotify": "https://open.spotify.com/episode/5XHadbN1UnL1Zp2ipDsk1o"
+  },
+  {
+    "title": "Eine kurze Geschichte des Fahrrads",
+    "tag": "gag442",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000648924288",
+    "url_spotify": "https://open.spotify.com/episode/7xn0EQD9rnalFiFTSvpjLv"
+  },
+  {
+    "title": "Jemima Nicholas und die Schlacht von Fishguard",
+    "tag": "gag441",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000648088616",
+    "url_spotify": "https://open.spotify.com/episode/3UqDAZHrNthDojZSJS07gd"
+  },
+  {
+    "title": "Eine Giraffe für den König",
+    "tag": "gag440",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000647214270",
+    "url_spotify": "https://open.spotify.com/episode/1ihRKSFRdS5grkF9Vq6LoH"
+  },
+  {
+    "title": "Kyros II. und die Entstehung eines Mythos",
+    "tag": "gag439",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000646053195",
+    "url_spotify": "https://open.spotify.com/episode/07K1lm94M1ua9FHhPNdhDA"
+  },
+  {
+    "title": "Die Pinkerton-Detektei",
+    "tag": "gag438",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000645186516",
+    "url_spotify": "https://open.spotify.com/episode/0HAbZ6vA0jQaNahnK9k8SV"
+  },
+  {
+    "title": "Die holprige Karriere des Reißverschlusses",
+    "tag": "gag437",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000644264926",
+    "url_spotify": "https://open.spotify.com/episode/5JTAR5GPWF0InVhPElP1nO"
+  },
+  {
+    "title": "Post aus der Antarktis, Korrekturen zum Deutsch-Französischen Krieg und vieles mehr",
+    "tag": "fgag13",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000644055598",
+    "url_spotify": "https://open.spotify.com/episode/4wFxsrC2hcsWVeos9RJ2oY"
+  },
+  {
+    "title": "Die Jagd nach El­do­ra­do",
+    "tag": "gag436",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000643573981",
+    "url_spotify": "https://open.spotify.com/episode/13NjRiee0mU3uLTQULl6G5"
+  },
+  {
+    "title": "Die Schlacht bei Carrhae",
+    "tag": "gag435",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000642640291",
+    "url_spotify": "https://open.spotify.com/episode/494YGqkk4Wq4s6TGG4ZAwS"
+  },
+  {
+    "title": "Ein willkommener Mörder",
+    "tag": "gag434",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000641895496",
+    "url_spotify": "https://open.spotify.com/episode/4jvurbgxZhc226qfIGuR0W"
+  },
+  {
+    "title": "Der Schinderhannes",
+    "tag": "gag433",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000641037112",
+    "url_spotify": "https://open.spotify.com/episode/76fsJ0DFVQl8oWhkM5XlvD"
+  },
+  {
+    "title": "Ein bitteres Heilmittel",
+    "tag": "gag432",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000640365150",
+    "url_spotify": "https://open.spotify.com/episode/0BNvvaAhtn5z9ExySztWa1"
+  },
+  {
+    "tag": "gag431",
+    "title": "Auguste Escoffier, Kaiser der Köche",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000639733434",
+    "url_spotify": "https://open.spotify.com/episode/6yL6CF3JX4GS9NhKbYtvwB"
+  },
+  {
+    "tag": "fgag12",
+    "title": "Viel Post, viel Feedback, viel Freude",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000639547729",
+    "url_spotify": "https://open.spotify.com/episode/1ftkfPlFJn6KpQwATv90Vm"
+  },
+  {
+    "tag": "gag430",
+    "title": "Gefangene und Königin – Johanna I. von Kastilien",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/id1044844618?i=1000639093010",
+    "url_spotify": "https://open.spotify.com/episode/0WqzIuRDvW6heOYa1FpdDX"
+  },
+  {
+    "tag": "gag429",
+    "title": "Der Eimerkrieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000638321858",
+    "url_spotify": "https://open.spotify.com/episode/27ZzzrEKXRv1EzuPsMtayK"
+  },
+  {
+    "tag": "gag428",
+    "title": "Der Fälscher Konstantinos Simonides",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000637567530",
+    "url_spotify": "https://open.spotify.com/episode/7hmH1wzl0iNDo9XNdSg9lu"
+  },
+  {
+    "tag": "gag427",
+    "title": "Das große Erdbeben von Lissabon",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000636791860",
+    "url_spotify": "https://open.spotify.com/episode/3Xqud86b5jFoueOM2ztKZU"
+  },
+  {
+    "tag": "gag426",
+    "title": "Die erste Regisseurin – Alice Guy",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000635649882",
+    "url_spotify": "https://open.spotify.com/episode/7wSpYESpS2ydF9ck15j76c"
+  },
+  {
+    "tag": "gag425",
+    "title": "Shampooing und die vier Leben des Dean Mahomet",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000634646551",
+    "url_spotify": "https://open.spotify.com/episode/4wwdYl0GLqnbmhOJuGuWlM"
+  },
+  {
+    "tag": "gag424",
+    "title": "Die Erfindung der Briefmarke",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000634052837",
+    "url_spotify": "https://open.spotify.com/episode/0mujyQEJhgk9a7AzufD3dK"
+  },
+  {
+    "tag": "gag423",
+    "title": "Der Sohn Gottes Hong Xiuquan und sein Aufstand gegen das imperiale China",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000633140328",
+    "url_spotify": "https://open.spotify.com/episode/0kxC5sgRVodCu9ykwPOZzT"
+  },
+  {
+    "tag": "gag422",
+    "title": "Eine kleine Geschichte der Parapsychologie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000632463512",
+    "url_spotify": "https://open.spotify.com/episode/5pClVdyRPvDh0lF2CJf66s"
+  },
+  {
+    "tag": "gag421",
+    "title": "Playfair und die Erfindung des Balkendiagramms",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000631577194",
+    "url_spotify": "https://open.spotify.com/episode/7Hif8qSW7HBSdqx31OuXmF"
+  },
+  {
+    "tag": "gag420",
+    "title": "Harry Anslinger und der erste \"War on Drugs\"",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000630850131",
+    "url_spotify": "https://open.spotify.com/episode/7poDiZofCFHLUd3sYGMlqG"
+  },
+  {
+    "tag": "gag419",
+    "title": "Therese von Thurn und Taxis und das Ende der Reichspost",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000630091149",
+    "url_spotify": "https://open.spotify.com/episode/52HKUjBXYIlhiHb49fguP4"
+  },
+  {
+    "tag": "gag418",
+    "title": "Das älteste Gewürz der Welt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000629174492",
+    "url_spotify": "https://open.spotify.com/episode/0h9zUGpJS2hMHBCAlnlc7u"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000628917483",
+    "url_spotify": "https://open.spotify.com/episode/0KvgeVhE2e2oIspY5rA7ib",
+    "title": "Samuel Pepys, Lady Six Sky und Daniel singt",
+    "tag": "fgag11"
+  },
+  {
+    "tag": "gag417",
+    "title": "Auf der Suche nach den Quellen des Nils",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000628503911",
+    "url_spotify": "https://open.spotify.com/episode/323apOXR2RCITt7l5KB4Ru"
+  },
+  {
+    "tag": "gag416",
+    "title": "Wie das Münzgeld entstand",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000627490415",
+    "url_spotify": "https://open.spotify.com/episode/1Sw43hTkJdXKsfi6Aiye9Q"
+  },
+  {
+    "tag": "gag415",
+    "title": "Polarpionier Fridtjof Nansen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000626721063",
+    "url_spotify": "https://open.spotify.com/episode/3DUJ1LwVcgIhpkkY7IrFLN"
+  },
+  {
+    "tag": "gag414",
+    "title": "Ibn Fadlān und die Reise zur Wolga",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000626087460",
+    "url_spotify": "https://open.spotify.com/episode/4j7CKhEsB1FDQOR1p3NIyj"
+  },
+  {
+    "tag": "gag413",
+    "title": "Paracelsus – Arzt und Alchemist",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000625306816",
+    "url_spotify": "https://open.spotify.com/episode/7zaLPssTvryNMJA7WEGekZ"
+  },
+  {
+    "tag": "gag412",
+    "title": "Samuel Pepys und das außergewöhnlichste Tagebuch des 17. Jahrhunderts",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000624291170",
+    "url_spotify": "https://open.spotify.com/episode/4eEHaoAWheBQUsqDt3bxoY"
+  },
+  {
+    "tag": "gag411",
+    "title": "Der Untergang der Thomas W. Lawson",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000623846225",
+    "url_spotify": "https://open.spotify.com/episode/2pVvKDIFV3sWW2h33dxraG"
+  },
+  {
+    "tag": "gag410",
+    "title": "Lady Six Sky und eine kurze Geschichte der Maya",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000623048236",
+    "url_spotify": "https://open.spotify.com/episode/7EluT4JIKGxDGV92Wmp1iO"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000622805862",
+    "url_spotify": "https://open.spotify.com/episode/3oikpzqnBDECLO9fEDcSJ5",
+    "title": "Die Rückkehr, eine Ankündigung und ein Interview",
+    "tag": "fgag10"
+  },
+  {
+    "tag": "gag409",
+    "title": "Pferdefotos und ein Mord",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000622298642",
+    "url_spotify": "https://open.spotify.com/episode/6BJsa1KOPyNeO3jtDVQDLe"
+  },
+  {
+    "tag": "gag408",
+    "title": "Das kurze und tragische Leben des Évariste Galois",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000621411576",
+    "url_spotify": "https://open.spotify.com/episode/1Naq643qaXfN6Z5inbxbde"
+  },
+  {
+    "tag": "gag407",
+    "title": "Das katastrophale Ende einer Kolonie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000620822300",
+    "url_spotify": "https://open.spotify.com/episode/3vLIKH763L6htdAKXGGiA7"
+  },
+  {
+    "tag": "gag406",
+    "title": "Die SMS Wolf und die Piraten des Kaisers",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000619254302",
+    "url_spotify": "https://open.spotify.com/episode/4usCnESJcPoug0uPjcclyS"
+  },
+  {
+    "tag": "gag405",
+    "title": "Bonifatius, Apostel der Deutschen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000618475480",
+    "url_spotify": "https://open.spotify.com/episode/3ycfXc6Ik8tA7SEqjLhnQr"
+  },
+  {
+    "tag": "gag404",
+    "title": "Not Found",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000617699118",
+    "url_spotify": "https://open.spotify.com/episode/3Ho2Y9H9oAOcMihzd5ltNf"
+  },
+  {
+    "tag": "gag403",
+    "title": "Maxentius – Der letzte Kaiser in Rom",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000616816141",
+    "url_spotify": "https://open.spotify.com/episode/6l6YLiTugae4Xfb8uvpi5Y"
+  },
+  {
+    "tag": "gag402",
+    "title": "Die Vegetarian Society und die Begründung des modernen Vegetarismus",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000615868154",
+    "url_spotify": "https://open.spotify.com/episode/0h3nKBXgksyErQ0gG1HAR3"
+  },
+  {
+    "tag": "gag401",
+    "title": "Amerika und die Weltkarte von Waldseemüller",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000615045038",
+    "url_spotify": "https://open.spotify.com/episode/7pB4E5GbILiABYRx0xi0vQ"
+  },
+  {
+    "tag": "gag400",
+    "title": "GAG X Anno Mundi – Anicia Juliana",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000614272530",
+    "url_spotify": "https://open.spotify.com/episode/33ZZ4TvWCe1fmFBEbHOwBV"
+  },
+  {
+    "tag": "gag399",
+    "title": "John Brown und sein gescheiterter Sklavenaufstand",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000613205069",
+    "url_spotify": "https://open.spotify.com/episode/071RVIzXd5Y9PXDrLV4KkU"
+  },
+  {
+    "tag": "gag398",
+    "title": "Der Goldene Brief",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000612302102",
+    "url_spotify": "https://open.spotify.com/episode/3ESDt2JMHku1Bh7J1OZmUI"
+  },
+  {
+    "tag": "gag397",
+    "title": "Hy Brasil",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000611281335",
+    "url_spotify": "https://open.spotify.com/episode/6TIY43fiPvadsBkB91rLIz"
+  },
+  {
+    "tag": "gag396",
+    "title": "Helene Kottannerin und der Raub der Stephanskrone",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000610561792",
+    "url_spotify": "https://open.spotify.com/episode/71tzGjiFFzsSlm0x60vIYs"
+  },
+  {
+    "tag": "gag395",
+    "title": "Barbe-Nicole Ponsardin und die Begründung eines Champagnerimperiums",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000609487014",
+    "url_spotify": "https://open.spotify.com/episode/7EeFvRdpjZtCmvQCx9aACQ"
+  },
+  {
+    "tag": "gag394",
+    "title": "Die Verurteilung von Sacco und Vanzetti",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000608401258",
+    "url_spotify": "https://open.spotify.com/episode/1q9a6eULL6QR9LIzyFMqKg"
+  },
+  {
+    "tag": "gag393",
+    "title": "Die Schlacht von Zama",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000607485890",
+    "url_spotify": "https://open.spotify.com/episode/60aAlOr3F4KaCYJ5pBYxh2"
+  },
+  {
+    "tag": "gag392",
+    "title": "Phosphor und der Streik der Streichholzarbeiterinnen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000606284100",
+    "url_spotify": "https://open.spotify.com/episode/7lwYowFINltY7TGhzFCmzF"
+  },
+  {
+    "tag": "gag391",
+    "title": "Celia Cooney, die Banditin mit der Kurzhaarfrisur",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000605061109",
+    "url_spotify": "https://open.spotify.com/episode/7j1tlucLVjbJqgnJDN1oyf"
+  },
+  {
+    "tag": "gag390",
+    "title": "Kleopatra Selene und das Ende der Römischen Republik",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000604132418",
+    "url_spotify": "https://open.spotify.com/episode/5iMNLFjRiIMEkFWWpOoTqd"
+  },
+  {
+    "tag": "gag389",
+    "title": "Spieglein, Spieglein an der Wand",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000603260848",
+    "url_spotify": "https://open.spotify.com/episode/5fL7hb3Li7zSVtGsExTXaM"
+  },
+  {
+    "tag": "gag388",
+    "title": "Marie Tussaud und die Wachsfiguren",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000602099169",
+    "url_spotify": "https://open.spotify.com/episode/599lEEoWGsnLWTGMgM2HBT"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000601576673",
+    "url_spotify": "https://open.spotify.com/episode/1tVvrum0BdEWRWYi0liruw",
+    "title": "Theodor von Neuhoff, Verwirrungen im metrischen System und warum Bletchley Park den Krieg verkürzte",
+    "tag": "fgag9"
+  },
+  {
+    "tag": "gag387",
+    "title": "Nurhaci und die Entstehung der Mandschu",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000600930095",
+    "url_spotify": "https://open.spotify.com/episode/3DRH31vYzfdsa6hvDSRzqu"
+  },
+  {
+    "tag": "gag386",
+    "title": "Der Wettlauf zum Nordpol",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000599616659",
+    "url_spotify": "https://open.spotify.com/episode/4fgXxqWtqe5liPo0nozwbN"
+  },
+  {
+    "tag": "gag385",
+    "title": "Delmonico's und der erste Starkoch der USA",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000598487977",
+    "url_spotify": "https://open.spotify.com/episode/0o6gBxeqpYWuNXenT8g8jA"
+  },
+  {
+    "tag": "gag384",
+    "title": "Flaschenpost und die Erforschung der Ozeane",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000597409855",
+    "url_spotify": "https://open.spotify.com/episode/6Ow1qsEuVVtww7znhARD5A"
+  },
+  {
+    "tag": "gag383",
+    "title": "Bletchley Park",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000596383457",
+    "url_spotify": "https://open.spotify.com/episode/6MqxA6iJO5suy0a6EhfdYz"
+  },
+  {
+    "tag": "gag382",
+    "title": "Der erste Film",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000595069993",
+    "url_spotify": "https://open.spotify.com/episode/6EBHq2oNjnX9EIM4wX4vh7"
+  },
+  {
+    "tag": "gag381",
+    "title": "Mau Piailug und die Besiedelung des Pazifiks",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000593499065",
+    "url_spotify": "https://open.spotify.com/episode/1yKqQS2C7a1t7ZdyBnSNLn"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000592992416",
+    "url_spotify": "https://open.spotify.com/episode/0x56KC9w9Ea5qKdOEZeCHK",
+    "title": "In der Stratosphäre",
+    "tag": "fgag8"
+  },
+  {
+    "tag": "gag380",
+    "title": "Das Maß aller Dinge",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000592199826",
+    "url_spotify": "https://open.spotify.com/episode/3NqmohnX5qZQAAx9lXfpQA"
+  },
+  {
+    "tag": "gag379",
+    "title": "Theodor von Neuhoff - König von Korsika",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000591396639",
+    "url_spotify": "https://open.spotify.com/episode/07oRBPofKWIgZypLIzd210"
+  },
+  {
+    "tag": "gag378",
+    "title": "Ein langer Marsch durch Feindesland",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000590784721",
+    "url_spotify": "https://open.spotify.com/episode/3njA5iMrsvaLWojTSfRHZq"
+  },
+  {
+    "tag": "gag377",
+    "title": "Aufstieg und Fall des Templerordens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000590045562",
+    "url_spotify": "https://open.spotify.com/episode/645B9arZRseafJ2uHr6ieQ"
+  },
+  {
+    "tag": "gag376",
+    "title": "Nagelmackers und der Orient-Express",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000589118983",
+    "url_spotify": "https://open.spotify.com/episode/2YA333ta4eVHBuoV2RhRTX"
+  },
+  {
+    "tag": "gag375",
+    "title": "Sofia Kowalewskaja, \"Königin der Wissenschaft\"",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000587914310",
+    "url_spotify": "https://open.spotify.com/episode/4K5f7FA5o1dM5pL1ToGQDY"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000587604551",
+    "url_spotify": "https://open.spotify.com/episode/1CjwGUWFlHcTpcK78CX9dP",
+    "title": "Bibi & Tina, Casinos in Macau und noch mehr Schiffe in Maisfeldern",
+    "tag": "fgag7"
+  },
+  {
+    "tag": "gag374",
+    "title": "Ludwik Fleck und das Fleckfieber",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000587113881",
+    "url_spotify": "https://open.spotify.com/episode/6jG9f64ULNBbCttt3vooxu"
+  },
+  {
+    "tag": "gag373",
+    "title": "Morocco und der Kluge Hans",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000586141813",
+    "url_spotify": "https://open.spotify.com/episode/7yr8I56gD3roFmTk2JivOv"
+  },
+  {
+    "tag": "gag372",
+    "title": "Wie das Roulette eine Null verlor",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000585556096",
+    "url_spotify": "https://open.spotify.com/episode/3BpNw8EOhIPR2Am5OLK95V"
+  },
+  {
+    "tag": "gag371",
+    "title": "Galla Placidia",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000584653958",
+    "url_spotify": "https://open.spotify.com/episode/1dWrhLoDZyzDwOSv2C5zFS"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000584353460",
+    "url_spotify": "https://open.spotify.com/episode/1PoqBwSRdgJ1C29YCYVxNi",
+    "title": "Egostory, Schwesterschiff und ein Freispruch für die Gletscher",
+    "tag": "fgag6"
+  },
+  {
+    "tag": "gag370",
+    "title": "Der Kodex des Archimedes",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000583879315",
+    "url_spotify": "https://open.spotify.com/episode/74WbADI4ZVPlja4bqQqhsf"
+  },
+  {
+    "tag": "gag369",
+    "title": "Der Struwwelpeter",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000583127588",
+    "url_spotify": "https://open.spotify.com/episode/2C7Tzsvke6wOhDsoRlm5cY"
+  },
+  {
+    "tag": "gag368",
+    "title": "Wie das Jod ins Salz kam",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000582320849",
+    "url_spotify": "https://open.spotify.com/episode/0BfEJ7iEOyEDbpBYTnRbXz"
+  },
+  {
+    "tag": "gag367",
+    "title": "Untergang und Comeback der VASA",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000581644522",
+    "url_spotify": "https://open.spotify.com/episode/5BOJlSWrYotsqydJb19WuV"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000581286573",
+    "url_spotify": "https://open.spotify.com/episode/75TQVCDCc9LewnYesM0rqZ",
+    "title": "Duke in Paris, Jazzualdo und die Ghost Army",
+    "tag": "fgag5"
+  },
+  {
+    "tag": "gag366",
+    "title": "Das Attentat von Anagni",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000580832830",
+    "url_spotify": "https://open.spotify.com/episode/4RbsOV1N2fNqhRyX2CpYNx"
+  },
+  {
+    "tag": "gag365",
+    "title": "The Ghost Army",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000580158090",
+    "url_spotify": "https://open.spotify.com/episode/3nYr2NgEd8tw3s8OdTA1QB"
+  },
+  {
+    "tag": "gag364",
+    "title": "Mord und Madrigale – Carlo Gesualdo",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000579321767",
+    "url_spotify": "https://open.spotify.com/episode/5Z1w9KQ7ZwS1jLr60bbArs"
+  },
+  {
+    "tag": "gag363",
+    "title": "Duke Kahanamoku",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000578556859",
+    "url_spotify": "https://open.spotify.com/episode/1jrwqCzBwA7UVL39yVB44U"
+  },
+  {
+    "tag": "gag362",
+    "title": "Bayerns letzte Kurfürstin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000577840766",
+    "url_spotify": "https://open.spotify.com/episode/23eYk7vmb7qd1mroHb393K"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000577536066",
+    "url_spotify": "https://open.spotify.com/episode/3bmox23uiYQVag3MzIqM7g",
+    "title": "Reinhard und das Reis-Telefon",
+    "tag": "fgag4"
+  },
+  {
+    "tag": "gag361",
+    "title": "Gustave Trouvé - der vergessene Erfinder",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000577076144",
+    "url_spotify": "https://open.spotify.com/episode/6ypMcsbkeyts9iVkH0odTy"
+  },
+  {
+    "tag": "gag360",
+    "title": "Unglück am Matterhorn",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000576231061",
+    "url_spotify": "https://open.spotify.com/episode/1rvwr7vymqXzuVSVDMi8us"
+  },
+  {
+    "tag": "gag359",
+    "title": "Eine kleine Geschichte des Schachspiels",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000575522961",
+    "url_spotify": "https://open.spotify.com/episode/0lhKCVm07qi4sMUz1OWfGd"
+  },
+  {
+    "tag": "gag358",
+    "title": "Philipp Reis und die Erfindung des Telefons",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000574812482",
+    "url_spotify": "https://open.spotify.com/episode/0DPCPrbqxUmW8pZDRrJZRo"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000574516319",
+    "url_spotify": "https://open.spotify.com/episode/0ygbw6NRZ4VVtmUKhNMzwx",
+    "title": "Erwin Kreuz - ein Update",
+    "tag": "fgag3"
+  },
+  {
+    "tag": "gag357",
+    "title": "Mary Kingsley",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000571226092",
+    "url_spotify": "https://open.spotify.com/episode/5JgjPBBVJlj4joOrr9Nbi0"
+  },
+  {
+    "tag": "gag356",
+    "title": "Das DeLorean-Drama",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000570513486",
+    "url_spotify": "https://open.spotify.com/episode/3dVoTRNq5ZZYd70J2WAyWT"
+  },
+  {
+    "tag": "gag355",
+    "title": "Der Englische Schweiß",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000569655974",
+    "url_spotify": "https://open.spotify.com/episode/1LHUGifx9iOgwve439gwtd"
+  },
+  {
+    "tag": "gag354",
+    "title": "Die Halsbandaffäre",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000568931104",
+    "url_spotify": "https://open.spotify.com/episode/0kLRn01YrbTcHolzfoJ2vW"
+  },
+  {
+    "tag": "gag353",
+    "title": "Wallada",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000567988912",
+    "url_spotify": "https://open.spotify.com/episode/6lW3iEaZeUNXshmmD0tsnI"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000567587985",
+    "url_spotify": "https://open.spotify.com/episode/5DGvoxzoqX6bANdSEEzetJ",
+    "title": "Mord auf Ex",
+    "tag": "fgag2"
+  },
+  {
+    "tag": "gag352",
+    "title": "Wallace und das Rennen um die Evolutionstheorie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000567310021",
+    "url_spotify": "https://open.spotify.com/episode/3r1kjFzJlkeMDWoBo6wNwr"
+  },
+  {
+    "tag": "gag351",
+    "title": "Die Erfindung des Saxophons - Aufstieg und Fall des Adolphe Sax",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000566381434",
+    "url_spotify": "https://open.spotify.com/episode/6bOmMelXYJzAoT4CxPIqgQ"
+  },
+  {
+    "tag": "gag350",
+    "title": "Der Bauernkrieg und die Revolution von 1525",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000565555245",
+    "url_spotify": "https://open.spotify.com/episode/4o6bNtUiYX0qXRqa94rk0g"
+  },
+  {
+    "tag": "gag349",
+    "title": "Konstantin Phaulkon im Königreich Ayutthaya",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000564430382",
+    "url_spotify": "https://open.spotify.com/episode/1pBUaprompoulevMrhO7PL"
+  },
+  {
+    "tag": "gag348",
+    "title": "Der Anschlag auf die Mosel",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000563378005",
+    "url_spotify": "https://open.spotify.com/episode/2O84khezHm2bAEIE5a5Rft"
+  },
+  {
+    "tag": "gag347",
+    "title": "Adrianopel 378",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000561883145",
+    "url_spotify": "https://open.spotify.com/episode/3XMHOK1ecTQm02q6uz7poI"
+  },
+  {
+    "tag": "gag346",
+    "title": "Die längste Hängebrücke der Welt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000560365723",
+    "url_spotify": "https://open.spotify.com/episode/5Miu0Yww4t7G5SeeRG5mKD"
+  },
+  {
+    "tag": "gag345",
+    "title": "Suffrajitsu",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000559475571",
+    "url_spotify": "https://open.spotify.com/episode/5yZsoqYsVe0YHe7Flaizcb"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000559087695",
+    "url_spotify": "https://open.spotify.com/episode/5WDO2wTWbl3c3vODs9v4Dm",
+    "title": "Atlantropa",
+    "tag": "fgag1"
+  },
+  {
+    "tag": "gag344",
+    "title": "Der Artischockenkrieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000558836719",
+    "url_spotify": "https://open.spotify.com/episode/2XVlQ0WMRRqdUc6RDZfuT0"
+  },
+  {
+    "tag": "gag343",
+    "title": "Phoebus und die geplante Obsoleszenz",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000558127252",
+    "url_spotify": "https://open.spotify.com/episode/30b1HpKkZwfOQbY4stTK8C"
+  },
+  {
+    "tag": "gag342",
+    "title": "Das Stockholmer Blutbad",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000557449800",
+    "url_spotify": "https://open.spotify.com/episode/72fCjH4KYcZHwBH0YBySKE"
+  },
+  {
+    "tag": "gag341",
+    "title": "Der Exorzismus der Marthe Brossier",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000556392215",
+    "url_spotify": "https://open.spotify.com/episode/45fhh5sWBQ0iayg7HnNgBx"
+  },
+  {
+    "tag": "gag340",
+    "title": "Tauben, die Raketen steuern und Kybernetik",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000555683312",
+    "url_spotify": "https://open.spotify.com/episode/1otGUTMUFtt7P1LeXKdV82"
+  },
+  {
+    "tag": "gag339",
+    "title": "Der Vocoder",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000554957063",
+    "url_spotify": "https://open.spotify.com/episode/7M4gHT16LFGYdRODJryKu6"
+  },
+  {
+    "tag": "gag338",
+    "title": "Eine neue Gesellschaft – Frühsozialist Robert Owen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000554183534",
+    "url_spotify": "https://open.spotify.com/episode/0UtDiqbD3Hd98lkI18sCjK"
+  },
+  {
+    "tag": "gag337",
+    "title": "Über Hummer, Kaviar und wie das Loch in den Donut kam",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000553414266",
+    "url_spotify": "https://open.spotify.com/episode/7tK9tHNzF6GHefMaYAokih"
+  },
+  {
+    "tag": "gag336",
+    "title": "George Smith und die Entdeckung des Gilgamesch-Epos",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000552671470",
+    "url_spotify": "https://open.spotify.com/episode/6Zch4g9bB5tIZrstCCpZ4J"
+  },
+  {
+    "tag": "gag335",
+    "title": "Aqua Tofana und die Giftmischerinnen des 17. Jahrhunderts",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000551977326",
+    "url_spotify": "https://open.spotify.com/episode/61wkJd6BhqNKKPGfSxSgFK"
+  },
+  {
+    "tag": "gag334",
+    "title": "Rachel Carson und der stumme Frühling",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000551255899",
+    "url_spotify": "https://open.spotify.com/episode/6KoUzv5BLr96WIWSH4Jtoi"
+  },
+  {
+    "tag": "gag333",
+    "title": "Alexandria",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000550532186",
+    "url_spotify": "https://open.spotify.com/episode/2p9RddGLpyneh9qVPikXhN"
+  },
+  {
+    "tag": "gag332",
+    "title": "Wie Gregor MacGregor ein Land verkaufte, das es gar nicht gab",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000549752662",
+    "url_spotify": "https://open.spotify.com/episode/0vogVo5htsZLW0ZjBbz8SV"
+  },
+  {
+    "tag": "gag331",
+    "title": "Wie Tetris die Welt eroberte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000549035712",
+    "url_spotify": "https://open.spotify.com/episode/2LeI7kIpznuvLRti6sN5A6"
+  },
+  {
+    "tag": "gag330",
+    "title": "Zum Tode verurteilt – Catharina Linck alias Anastasius Lagrantinus Rosenstengel",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000548325330",
+    "url_spotify": "https://open.spotify.com/episode/1dYdoOM6qBwRw04SobOp3v"
+  },
+  {
+    "tag": "gag329",
+    "title": "Wie der Wolf zum Hund wurde",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000547641555",
+    "url_spotify": "https://open.spotify.com/episode/0Cuu1cTBT5YB891HDUl85f"
+  },
+  {
+    "tag": "gag328",
+    "title": "P. T. Barnum und die größte Show der Welt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000546982788",
+    "url_spotify": "https://open.spotify.com/episode/3E6nheQGDHrxuxYaTvQJjX"
+  },
+  {
+    "tag": "gag327",
+    "title": "Das große Geburtenrennen von Toronto",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000546403125",
+    "url_spotify": "https://open.spotify.com/episode/4pqV9aT8KfBFBujVsmWKyr"
+  },
+  {
+    "tag": "gag326",
+    "title": "Ausgestorbene und außergewöhnliche Berufe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000545751330",
+    "url_spotify": "https://open.spotify.com/episode/6rVekPkZANjxP7O3t1QRhU"
+  },
+  {
+    "tag": "gag325",
+    "title": "Der Große Smog von 1952",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000545025399",
+    "url_spotify": "https://open.spotify.com/episode/7s5EMgl5c6Tlv1Ot845OmW"
+  },
+  {
+    "tag": "gag324",
+    "title": "Mit dem Ballon zum Nordpol – Andrées Polarexpedition von 1897",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000544297879",
+    "url_spotify": "https://open.spotify.com/episode/1kMtaLBD0qCiATkysn33IW"
+  },
+  {
+    "tag": "gag323",
+    "title": "Die Republik Ezo und das Ende des Shogunats",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000543595979",
+    "url_spotify": "https://open.spotify.com/episode/55INRbxYgsGoEpk5en4WzW"
+  },
+  {
+    "tag": "gag322",
+    "title": "Portugal und der Seeweg nach Indien",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000542926944",
+    "url_spotify": "https://open.spotify.com/episode/7i4aTThxApd9rRBMayNGC6"
+  },
+  {
+    "tag": "gag321",
+    "title": "Aufstieg und möglicher Fall der Banane",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000542189759",
+    "url_spotify": "https://open.spotify.com/episode/433Ta0iBi14pS9AtS3xDf5"
+  },
+  {
+    "tag": "gag320",
+    "title": "In 72 Tagen um die Welt – Journalistin Nellie Bly",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000541320322",
+    "url_spotify": "https://open.spotify.com/episode/10c1VBb1PrpWnUvu0jyYtt"
+  },
+  {
+    "tag": "gag319",
+    "title": "Ashoka der Große",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000540601614",
+    "url_spotify": "https://open.spotify.com/episode/2C9oVi4J7yNf45092jZhz2"
+  },
+  {
+    "tag": "gag318",
+    "title": "Der Nuklearunfall von Goiânia",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000539861680",
+    "url_spotify": "https://open.spotify.com/episode/5S4DpowyY4uAy0s3Y8mqqi"
+  },
+  {
+    "tag": "gag317",
+    "title": "Roger Tichborne – die wundersame Rückkehr des Sohnes",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000539149490",
+    "url_spotify": "https://open.spotify.com/episode/3lPJ3bfRHWDBnOTOIHgVly"
+  },
+  {
+    "tag": "gag316",
+    "title": "Die Shakespeare-Unruhen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000538431068",
+    "url_spotify": "https://open.spotify.com/episode/2BRJfJZOSstye79sh3yo0n"
+  },
+  {
+    "tag": "gag315",
+    "title": "Der Mehlkrieg von 1775",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000537706361",
+    "url_spotify": "https://open.spotify.com/episode/37O2nSkHJWGFl6CJedKxjy"
+  },
+  {
+    "tag": "gag314",
+    "title": "Eine kurze Geschichte der Cholera",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000536965827",
+    "url_spotify": "https://open.spotify.com/episode/3qVR2NIRWhqU0xRl0u7qie"
+  },
+  {
+    "tag": "gag313",
+    "title": "Die Geschwister Herschel",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000536247199",
+    "url_spotify": "https://open.spotify.com/episode/6Bw5vncNzYDijOI66EHQMm"
+  },
+  {
+    "tag": "gag312",
+    "title": "Der beste aller Ritter – das Leben von Guillaume le Maréchal",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000535387902",
+    "url_spotify": "https://open.spotify.com/episode/3sg79xnYzX0p7f9p1PhL7X"
+  },
+  {
+    "tag": "gag311",
+    "title": "Der Imjin-Krieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000534669384",
+    "url_spotify": "https://open.spotify.com/episode/1eVkt34mAAt1GPLWYyzbmh"
+  },
+  {
+    "tag": "gag310",
+    "title": "Arbeitskampf, Streik und das Leben der Gewerkschaftspionierin Paula Thiede",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000533962682",
+    "url_spotify": "https://open.spotify.com/episode/0acf38Vkr4bY2CuSQxviF3"
+  },
+  {
+    "tag": "gag309",
+    "title": "Die Bestie des Gévaudan",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000533067723",
+    "url_spotify": "https://open.spotify.com/episode/64qYMdUQJ2J3o7r8opC8e7"
+  },
+  {
+    "tag": "gag308",
+    "title": "Eine kurze Geschichte des Urlaubs und Reisens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000532360410",
+    "url_spotify": "https://open.spotify.com/episode/1i3WcPDk4FtbArHSdahwWd"
+  },
+  {
+    "tag": "gag307",
+    "title": "Njinga, Königin von Ndongo und Matamba",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000531684024",
+    "url_spotify": "https://open.spotify.com/episode/29qCYhhk5Z3BiijVkqvgSj"
+  },
+  {
+    "tag": "gag306",
+    "title": "Motoren, Krieg und Inflation – Aufstieg und Fall des Unternehmers Camillo Castiglioni",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000530952734",
+    "url_spotify": "https://open.spotify.com/episode/2ok4FJPMqadmgj7LlM5kZv"
+  },
+  {
+    "tag": "gag305",
+    "title": "Der Piltdown-Mensch",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000530257591",
+    "url_spotify": "https://open.spotify.com/episode/4SHc9PD5EmM0MVpPxiH7WW"
+  },
+  {
+    "tag": "gag304",
+    "title": "Der Falschgeldbetrug von Alves dos Reis",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000529559340",
+    "url_spotify": "https://open.spotify.com/episode/1Dsg5WKRrtArbKnSU1Pd1n"
+  },
+  {
+    "tag": "gag303",
+    "title": "Brunelleschi und die Kathedrale von Florenz",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000528830787",
+    "url_spotify": "https://open.spotify.com/episode/2R1ib1bS7pkv9l9kA3Xs1K"
+  },
+  {
+    "tag": "gag302",
+    "title": "Sealand und die Gründung einer Mikronation",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000528090756",
+    "url_spotify": "https://open.spotify.com/episode/3AwTdKy8q1rwlesIHugTe6"
+  },
+  {
+    "tag": "gag301",
+    "title": "Mary Seacole",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000527334050",
+    "url_spotify": "https://open.spotify.com/episode/45ULwRUJXEB5JUdRrEozy1"
+  },
+  {
+    "tag": "gag300",
+    "title": "Der vorläufige Höhepunkt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000526584567",
+    "url_spotify": "https://open.spotify.com/episode/5HqRQaoOzJXUZDsdGD8x6D"
+  },
+  {
+    "tag": "gag299",
+    "title": "Wie Basketball von James Naismith",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000525705276",
+    "url_spotify": "https://open.spotify.com/episode/57rwoaE7gtgR4vQaHNQGyQ"
+  },
+  {
+    "tag": "gag298",
+    "title": "Die Grüne Fee und der Absinthismus",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000524749863",
+    "url_spotify": "https://open.spotify.com/episode/0MLTbFe0v7dttb6vUI7caQ"
+  },
+  {
+    "tag": "gag297",
+    "title": "Die Revolutionärin und (fast) vergessene Pionierin der Frauenbewegung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000523891170",
+    "url_spotify": "https://open.spotify.com/episode/5pE0gg7iOCuu8RBKVOKfMu"
+  },
+  {
+    "tag": "gag296",
+    "title": "Jeanne la Flamme und der bretonische Erbfolgekrieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000523142542",
+    "url_spotify": "https://open.spotify.com/episode/5lYNH3hXimieEjxcP8sAZc"
+  },
+  {
+    "tag": "gag295",
+    "title": "Die Verwandlung des Axolotls",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000522310353",
+    "url_spotify": "https://open.spotify.com/episode/6LBjT0ZXn0IkykpUZy8O4M"
+  },
+  {
+    "tag": "gag294",
+    "title": "Erwin Kreuz",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000521425513",
+    "url_spotify": "https://open.spotify.com/episode/5TkgEvuykn8KAizrLhh1Ax"
+  },
+  {
+    "tag": "gag293",
+    "title": "Als in Europa Menschen ausgestellt wurden",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000520236205",
+    "url_spotify": "https://open.spotify.com/episode/7zanBcCWEN2tJzxGutdJAm"
+  },
+  {
+    "tag": "gag292",
+    "title": "Paul Grüninger",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000518971209",
+    "url_spotify": "https://open.spotify.com/episode/4BWme3KK5tJdb7pN3NkJj7"
+  },
+  {
+    "tag": "gag291",
+    "title": "Ein erfolgreicher Kampf gegen die Kolonialisierung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000518012613",
+    "url_spotify": "https://open.spotify.com/episode/5JQnJyUmZrVj8IV4FvCFlE"
+  },
+  {
+    "tag": "gag290",
+    "title": "Der Angriff der Leichten Brigade",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000517078344",
+    "url_spotify": "https://open.spotify.com/episode/6PH0kizGCb2QwZgJxTcje5"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000515799265",
+    "url_spotify": "https://open.spotify.com/episode/1Mb1yjgq7YTJtnZ1WyrngK",
+    "title": "Dr. Emma Southon on murder in ancient Rome",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag289",
+    "title": "Ein Kreuzzug, der einen ungeahnten Verlauf nahm",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000516108030",
+    "url_spotify": "https://open.spotify.com/episode/71eMH7rr2I5jT5ziX9BcbU"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000515799265",
+    "url_spotify": "https://open.spotify.com/episode/1Mb1yjgq7YTJtnZ1WyrngK",
+    "title": "Dr. Emma Southon on murder in ancient Rome",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag288",
+    "title": "Der Senat, der über Leichen ging",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000515145206",
+    "url_spotify": "https://open.spotify.com/episode/0r8HST99XHE91JmyxBBUMw"
+  },
+  {
+    "tag": "gag287",
+    "title": "Eine kurze Geschichte des Ballonfahrens und Fallschirmspringens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000514195264",
+    "url_spotify": "https://open.spotify.com/episode/428jIJI3yKiVgorAxTKblO"
+  },
+  {
+    "tag": "gag286",
+    "title": "Die verschwundenen Seefrauen Islands",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000513393623",
+    "url_spotify": "https://open.spotify.com/episode/5iybS0Wp7P8IislwhMHqfq"
+  },
+  {
+    "tag": "gag285",
+    "title": "Joseph Petrosino und die Black Hand",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000512365861",
+    "url_spotify": "https://open.spotify.com/episode/05yQj3kbs0Amk8kXVEWtZv"
+  },
+  {
+    "tag": "gag284",
+    "title": "\"There is death in the pot\" - Friedrich Accum und die Lebensmittelfälscher",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000511400883",
+    "url_spotify": "https://open.spotify.com/episode/1PKaZ00iZL66kg9NxWcjwL"
+  },
+  {
+    "tag": "gag283",
+    "title": "Lola Montez",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000510441079",
+    "url_spotify": "https://open.spotify.com/episode/0V4uFcJh3PcShWwUQ2jqP6"
+  },
+  {
+    "tag": "gag282",
+    "title": "Fredegund, Brunhild und der merowingische Bruderkrieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000509506957",
+    "url_spotify": "https://open.spotify.com/episode/3IltSeST6fWdMx80dGkmbi"
+  },
+  {
+    "tag": "gag281",
+    "title": "Der Putschversuch vom 23. Februar 1981",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000508435496",
+    "url_spotify": "https://open.spotify.com/episode/6cVLdv70hpbOG8memCqEpr"
+  },
+  {
+    "tag": "gag280",
+    "title": "Der versunkene Kontinent Lemuria",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000507549646",
+    "url_spotify": "https://open.spotify.com/episode/1iBQWToyTEVoDfVC8PMLz5"
+  },
+  {
+    "tag": "gag279",
+    "title": "Muskat und Manhattan",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000506730217",
+    "url_spotify": "https://open.spotify.com/episode/3jrBBFZCntkOjQCiBv2d2x"
+  },
+  {
+    "tag": "gag278",
+    "title": "Von göttlichen Robotern und feuerspeienden Bullen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000505898445",
+    "url_spotify": "https://open.spotify.com/episode/6SgnyB2enAXngAyhQvgdSX"
+  },
+  {
+    "tag": "gag277",
+    "title": "Der Aufstand und Putsch von Wilmington",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000505176566",
+    "url_spotify": "https://open.spotify.com/episode/2ByFSLiciEnYfD2X30ZZ00"
+  },
+  {
+    "tag": "gag276",
+    "title": "Aufruhr am Sankt-Scholastika-Tag",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000504496046",
+    "url_spotify": "https://open.spotify.com/episode/6Dd7nKl0XsPKPEgOzusBLi"
+  },
+  {
+    "tag": "gag275",
+    "title": "Victor Lustig – Der Mann, der den Eiffelturm verkaufte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000503871113",
+    "url_spotify": "https://open.spotify.com/episode/7LCVdNKD0xJ8R8XWM0OuM7"
+  },
+  {
+    "tag": "gag274",
+    "title": "Das Petzvalobjektiv",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000503291159",
+    "url_spotify": "https://open.spotify.com/episode/1kzF1FcXkLGCw5cQzeVYK9"
+  },
+  {
+    "tag": "gag273",
+    "title": "Der Alchemist und Goldmacher Franz Tausend",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000502562017",
+    "url_spotify": "https://open.spotify.com/episode/34uKJ1Mq2kEIaJZbVI2NFE"
+  },
+  {
+    "tag": "gag272",
+    "title": "Am Ende der Welt - Napoleons letzte Jahre im Exil",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000501809308",
+    "url_spotify": "https://open.spotify.com/episode/2gMwsGrfYSqnBADTokrXsv"
+  },
+  {
+    "tag": "gag271",
+    "title": "Caroline Neuber und der Hanswurststreit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000501061756",
+    "url_spotify": "https://open.spotify.com/episode/6jTT98XS4sIyUA07rZ2lL7"
+  },
+  {
+    "tag": "gag270",
+    "title": "Eine thüringische Katastrophe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000500222396",
+    "url_spotify": "https://open.spotify.com/episode/2gRXvVETCvHR8ZP245Fwwj"
+  },
+  {
+    "tag": "gag269",
+    "title": "Monika Ertl und ein Mord im Generalkonsulat",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000499183420",
+    "url_spotify": "https://open.spotify.com/episode/5lmRE8EgSnQHKDGcNB07T2"
+  },
+  {
+    "tag": "gag268",
+    "title": "Die Gebrüder Kellogg und die Erfindung des Frühstücks",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000498115094",
+    "url_spotify": "https://open.spotify.com/episode/3dpr9peQml4hr8CCoaKvgb"
+  },
+  {
+    "tag": "gag267",
+    "title": "Die Leichensynode von 897",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000497167975",
+    "url_spotify": "https://open.spotify.com/episode/4oOUE9NmdnhKHsrqtUUEMB"
+  },
+  {
+    "tag": "gag266",
+    "title": "Die Schlacht von Azincourt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000496401450",
+    "url_spotify": "https://open.spotify.com/episode/2Pa7dgEQOObOPvtLvRpafB"
+  },
+  {
+    "tag": "gag265",
+    "title": "Syphilis und die Tuskegee-Syphilis-Studie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000495539319",
+    "url_spotify": "https://open.spotify.com/episode/6xeEjiDXOwnRdrzJvGAmz9"
+  },
+  {
+    "tag": "gag264",
+    "title": "Seondeok, erste Königin Koreas",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000494820355",
+    "url_spotify": "https://open.spotify.com/episode/281YcEOja1h3ad6ovSl2SP"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000494686309",
+    "url_spotify": "https://open.spotify.com/episode/20cc2z3Hi67gj3kIFMJZPo",
+    "title": "Ein Geschichten-Extra mit Monika Ankele über Psychiatriegeschichte",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag263",
+    "title": "Lavoisier und die Entdeckung des Sauerstoffs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000493989583",
+    "url_spotify": "https://open.spotify.com/episode/6rRQC3h7IVZy9wCauf3hqO"
+  },
+  {
+    "tag": "gag262",
+    "title": "Die Strawhat Riots",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000493157941",
+    "url_spotify": "https://open.spotify.com/episode/6zwNJxGTxAPDZ2QqBobiEd"
+  },
+  {
+    "tag": "gag261",
+    "title": "Adam Worth, der Napoleon des Verbrechens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000492312289",
+    "url_spotify": "https://open.spotify.com/episode/1Nf9a51xLdafqFnzIPLsin"
+  },
+  {
+    "tag": "gag260",
+    "title": "Der Rattenfänger von Hameln",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000491480850",
+    "url_spotify": "https://open.spotify.com/episode/2LLhiW5tQfoXMGYFOIo5bv"
+  },
+  {
+    "tag": "gag259",
+    "title": "Operation Mincemeat – Eine Geheimdienstaktion während des Zweiten Weltkriegs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000490585058",
+    "url_spotify": "https://open.spotify.com/episode/2XWlZYZBNxXHY4FeLd9Q8A"
+  },
+  {
+    "tag": "gag258",
+    "title": "Der Andrews Raid - Eine Lokomotive auf Abwegen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000489908196",
+    "url_spotify": "https://open.spotify.com/episode/1YUCLumEBVY35EYzHSCiYU"
+  },
+  {
+    "tag": "gag257",
+    "title": "Alexander von Humboldt – Bugtales.FM Crossover",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000489210531",
+    "url_spotify": "https://open.spotify.com/episode/4s0F8AoCsEFrL7xZLrW2Br"
+  },
+  {
+    "tag": "gag256",
+    "title": "Der Rütlischwur und die Anfänge der Schweizerischen Eidgenossenschaft",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000488589934",
+    "url_spotify": "https://open.spotify.com/episode/5uwiImm4z32jx5lQMu9qmk"
+  },
+  {
+    "tag": "gag255",
+    "title": "Die 47 Ronin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000487885175",
+    "url_spotify": "https://open.spotify.com/episode/4VHECyzkXpF72EHMxIlhOm"
+  },
+  {
+    "tag": "gag254",
+    "title": "Eine kurze Geschichte des Kautschuks",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000487164327",
+    "url_spotify": "https://open.spotify.com/episode/4JnXaRpQM43B55RaiV2Deg"
+  },
+  {
+    "tag": "gag253",
+    "title": "Martin Frobisher und die Steine",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000486471864",
+    "url_spotify": "https://open.spotify.com/episode/5uR9wfk12K452UG5StoqNW"
+  },
+  {
+    "tag": "gag252",
+    "title": "Harvard Computers – Wie Astronominnen die Sterne neu sortierten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000485689906",
+    "url_spotify": "https://open.spotify.com/episode/4Dza83xmUd3rbn49alkxvA"
+  },
+  {
+    "tag": "gag251",
+    "title": "Der Schachtürke",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000484995557",
+    "url_spotify": "https://open.spotify.com/episode/1VnHUgoLUrkLWKBGZDjMNZ"
+  },
+  {
+    "tag": "gag250",
+    "title": "Eine kurze Geschichte der Bluttransfusion",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000483473726",
+    "url_spotify": "https://open.spotify.com/episode/6TTZPRYdWtFbKdK9pBstwW"
+  },
+  {
+    "tag": "gag249",
+    "title": "Das Malireich und die Pilgerreise des vielleicht reichsten Mannes der Geschichte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000481693164",
+    "url_spotify": "https://open.spotify.com/episode/78jVxozQ9jJFJ1STOgL1XO"
+  },
+  {
+    "tag": "gag248",
+    "title": "Der Venustransit von 1761/69 und das erste wissenschaftliche Großprojekt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000479385823",
+    "url_spotify": "https://open.spotify.com/episode/01etzc2J3No5zl0PLR9duV"
+  },
+  {
+    "tag": "gag247",
+    "title": "Der Emu Krieg von 1932",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000478305863",
+    "url_spotify": "https://open.spotify.com/episode/6S9DzR3yy6lm1Yv9UmmJlg"
+  },
+  {
+    "tag": "gag246",
+    "title": "John Law und die Mississippi-Blase",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000477396158",
+    "url_spotify": "https://open.spotify.com/episode/4XilWwtkAffSpiQltWYUsi"
+  },
+  {
+    "tag": "gag245",
+    "title": "Operation Paul Bunyan",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000476630178",
+    "url_spotify": "https://open.spotify.com/episode/4qrqhYu95WE1qhpTYuecZK"
+  },
+  {
+    "tag": "gag244",
+    "title": "Die Mühle von Auriol und warum ihre Zerstörung eine Besetzung Frankreichs verhindert hat",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000475920023",
+    "url_spotify": "https://open.spotify.com/episode/0CIafalUvNJBmfci0ih3Kq"
+  },
+  {
+    "tag": "gag243",
+    "title": "Aeneas Coffey und eine kleine Geschichte des irischen Whiskeys",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000475174707",
+    "url_spotify": "https://open.spotify.com/episode/0IBffZqWaGFFwhSe8TYQBC"
+  },
+  {
+    "tag": "gag242",
+    "title": "Eine kurze Geschichte der Olympischen Spiele (der Neuzeit)",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000474438815",
+    "url_spotify": "https://open.spotify.com/episode/5E5noAboagdqcs8wF56GlK"
+  },
+  {
+    "tag": "gag241",
+    "title": "General Königsmarck und der größte Kunstraub aller Zeiten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000473745640",
+    "url_spotify": "https://open.spotify.com/episode/3wx3TWEqJ4R2mgjy8yu2Dj"
+  },
+  {
+    "tag": "gag240",
+    "title": "René Blondlot und die Entdeckung der N-Strahlen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000473003049",
+    "url_spotify": "https://open.spotify.com/episode/1TQX5qqSeBEK4tzpE0MLHG"
+  },
+  {
+    "tag": "gag239",
+    "title": "Die Zabern-Affäre",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000472270110",
+    "url_spotify": "https://open.spotify.com/episode/2IvnbdZydBO7Pw9rdojrJV"
+  },
+  {
+    "tag": "gag238",
+    "title": "Kurze Geschichten ausgestorbener Berufe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000471534492",
+    "url_spotify": "https://open.spotify.com/episode/6uFqN11ZoRY47fXefeHiyu"
+  },
+  {
+    "tag": "gag237",
+    "title": "Friedrich Anton Mesmer und der Animalische Magnetismus",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000470854979",
+    "url_spotify": "https://open.spotify.com/episode/07dtYVbGDa8T2no1Uc6ljR"
+  },
+  {
+    "tag": "gag236",
+    "title": "Monopoly – Die Geschichte eines Brettspiels",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000470169170",
+    "url_spotify": "https://open.spotify.com/episode/76lqMcKa2xyVxYDu1rx1wb"
+  },
+  {
+    "tag": "gag235",
+    "title": "Die Quarzkrise",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000469442938",
+    "url_spotify": "https://open.spotify.com/episode/1NRReziTN60F4wuP1IYLPI"
+  },
+  {
+    "tag": "gag234",
+    "title": "Das bekannteste Parfüm der Welt und seine russische Vorgeschichte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000468762068",
+    "url_spotify": "https://open.spotify.com/episode/6rL6rghyTzhtdohnRDv7VM"
+  },
+  {
+    "tag": "gag233",
+    "title": "Norton I., Kaiser der USA",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000468084892",
+    "url_spotify": "https://open.spotify.com/episode/1KFu2JGCrSwcfFHEGyCqfh"
+  },
+  {
+    "tag": "gag232",
+    "title": "Ein Mordfall und das umfangreichste Wörterbuch der englischen Sprache",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000467417218",
+    "url_spotify": "https://open.spotify.com/episode/5S24PAAGzqyuFA1UlNldHX"
+  },
+  {
+    "tag": "gag231",
+    "title": "Die Große Enttäuschung von 1844",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000466728211",
+    "url_spotify": "https://open.spotify.com/episode/7Bd0WcREpgDeNtlw1NgzGv"
+  },
+  {
+    "tag": "gag230",
+    "title": "Die Tendaguru-Expedition und das größte Dinosaurierskelett der Welt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000466047536",
+    "url_spotify": "https://open.spotify.com/episode/7tznuBeYsC8YFKKuUdRO9U"
+  },
+  {
+    "tag": "gag229",
+    "title": "Elisabeth Báthory, die (angebliche) Blutgräfin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000465362101",
+    "url_spotify": "https://open.spotify.com/episode/3NlBPVUqWCg4kGrNhv7GGy"
+  },
+  {
+    "tag": "gag228",
+    "title": "Berliner Blau – die Erfindung einer Farbe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000464675000",
+    "url_spotify": "https://open.spotify.com/episode/6uDvjQyFjbByhT99vskAgO"
+  },
+  {
+    "tag": "gag227",
+    "title": "Die unsterbliche Henrietta Lacks",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000463992757",
+    "url_spotify": "https://open.spotify.com/episode/4IQYagq53IgVkUWVCJzalB"
+  },
+  {
+    "tag": "gag226",
+    "title": "Der Untergang der Batavia",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000463335902",
+    "url_spotify": "https://open.spotify.com/episode/66kjOfaMhCutkqF3TDmaeT"
+  },
+  {
+    "tag": "gag225",
+    "title": "Die Rundfahrt der Schlachtfelder",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000462559652",
+    "url_spotify": "https://open.spotify.com/episode/0fTXwrcCDDCFsDPUpXfs13"
+  },
+  {
+    "tag": "gag224",
+    "title": "Die Balmis-Expedition und eine kurze Geschichte der Pockenimpfung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000461892380",
+    "url_spotify": "https://open.spotify.com/episode/4A7aE63NKR7jf7tTxZlx2m"
+  },
+  {
+    "tag": "gag223",
+    "title": "Ramen und die Transformation Japans",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000461288040",
+    "url_spotify": "https://open.spotify.com/episode/50h6f1FrFNT6llalMjSO3G"
+  },
+  {
+    "tag": "gag222",
+    "title": "Das Voynich-Manuskript",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000460725936",
+    "url_spotify": "https://open.spotify.com/episode/4FvRgif4UcXZOjF1fkPajK"
+  },
+  {
+    "tag": "gag221",
+    "title": "Hans Staden - ein Landsknecht bei den Menschenfressern",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000459951309",
+    "url_spotify": "https://open.spotify.com/episode/1d3tER1qt0pY7EehCOM3Mk"
+  },
+  {
+    "tag": "gag220",
+    "title": "Eine kurze Geschichte der Rohrpost",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000459280058",
+    "url_spotify": "https://open.spotify.com/episode/1YL2gWjlxSqqzqYDD4WbdP"
+  },
+  {
+    "tag": "gag219",
+    "title": "Die Kotze-Affäre",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000458628401",
+    "url_spotify": "https://open.spotify.com/episode/3jv6WCyW2LwKmStsvXHtx1"
+  },
+  {
+    "tag": "gag218",
+    "title": "Die Pazzi-Verschwörung und der Aufstieg der Medici",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000457994313",
+    "url_spotify": "https://open.spotify.com/episode/3cU4QJdlNWPHWSPtDkEWUg"
+  },
+  {
+    "tag": "gag217",
+    "title": "Wie Joseph Haydn den Kopf verlor",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000457322177",
+    "url_spotify": "https://open.spotify.com/episode/2vRfkomN5tuQFDEZUPIRWP"
+  },
+  {
+    "tag": "gag216",
+    "title": "Napoleon II. – Vom König von Rom zum Herzog von Reichstadt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000456676271",
+    "url_spotify": "https://open.spotify.com/episode/63mst94aiuQK6jDrd57LYD"
+  },
+  {
+    "tag": "gag215",
+    "title": "Wojtek, polnischer Soldatenbär",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000456064465",
+    "url_spotify": "https://open.spotify.com/episode/53U4h83kSsW7e2uoknoeqf"
+  },
+  {
+    "tag": "gag214",
+    "title": "Hedy Lamarr – Hollywoodstar und Erfinderin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000455477289",
+    "url_spotify": "https://open.spotify.com/episode/3iGpL3K2W0FMFjBPu6qDWQ"
+  },
+  {
+    "tag": "gag213",
+    "title": "Tom Morris und eine kleine Geschichte des Golfsports",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000454580729",
+    "url_spotify": "https://open.spotify.com/episode/0j0fkWTTVaf8ccSlmoRWw3"
+  },
+  {
+    "tag": "gag212",
+    "title": "Eine kleine Geschichte der Sternbilder",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000453701477",
+    "url_spotify": "https://open.spotify.com/episode/3Ldr3CI7GygvKTA52oUaDv"
+  },
+  {
+    "tag": "gag211",
+    "title": "Griechisches Feuer",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000452867746",
+    "url_spotify": "https://open.spotify.com/episode/7KZiBeKYKzwMI28FCqanbq"
+  },
+  {
+    "tag": "gag210",
+    "title": "Der Kunstfälscher Han van Meegeren",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000452007215",
+    "url_spotify": "https://open.spotify.com/episode/0w4QdoLGFw9NYKCRMojetw"
+  },
+  {
+    "tag": "gag209",
+    "title": "Cyriacus und die Erfindung der Archäologie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000451154292",
+    "url_spotify": "https://open.spotify.com/episode/05u0WBjX7MzJNWRDObp5Yq"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000450675527",
+    "url_spotify": "https://open.spotify.com/episode/58j4AKnlXQdXwbXMPlm6cB",
+    "title": "Interview mit René Feldvoß über Eishockey in der DDR",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag208",
+    "title": "Die kleinste Liga der Welt – Eishockey in der DDR",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000450192112",
+    "url_spotify": "https://open.spotify.com/episode/2WambpsX4xKVMJhSp9Uc5n"
+  },
+  {
+    "tag": "gag207",
+    "title": "William Stewart Halsted und die Chirurgie des 19. Jahrhunderts",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000449353568",
+    "url_spotify": "https://open.spotify.com/episode/7biu92UAyqAKL7Aw2qW14h"
+  },
+  {
+    "tag": "gag206",
+    "title": "Von Verliesen & Drachen - ein 3W6 Crossover",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000448529208",
+    "url_spotify": "https://open.spotify.com/episode/3bZ8y6bk6KJpWbVzyc5pWD"
+  },
+  {
+    "tag": "gag205",
+    "title": "Die Befreiung von Schloss Itter",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000447991082",
+    "url_spotify": "https://open.spotify.com/episode/15haRi9o6LkGJtdWn5a13R"
+  },
+  {
+    "tag": "gag204",
+    "title": "Obaysch - das viktorianische Nilpferd",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000447421816",
+    "url_spotify": "https://open.spotify.com/episode/3Al3zZ5OVcNLswzCjluuxH"
+  },
+  {
+    "tag": "gag203",
+    "title": "Bleiben oder gehen? Die Option in Südtirol 1939",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000446871758",
+    "url_spotify": "https://open.spotify.com/episode/1b2XC5z4HRz9EvARjZvTXV"
+  },
+  {
+    "tag": "gag202",
+    "title": "Über Brunzdoktoren und Uroskopie – die Harnschau in der vormodernen Medizin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000446345220",
+    "url_spotify": "https://open.spotify.com/episode/6uWNzzJe8YBmENSnBUrVVB"
+  },
+  {
+    "tag": "gag201",
+    "title": "Eine kleine Geschichte des Speiseeises",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000445770328",
+    "url_spotify": "https://open.spotify.com/episode/5OLtNdeUIwvFR110iMIjqp"
+  },
+  {
+    "tag": "gag200",
+    "title": "Eine Abrechnung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000445199189",
+    "url_spotify": "https://open.spotify.com/episode/4I6YUm7gC7wR6d9s1RNcke"
+  },
+  {
+    "tag": "gag199",
+    "title": "UC 71 und der U-Boot-Krieg im Ersten Weltkrieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000444665828",
+    "url_spotify": "https://open.spotify.com/episode/7zKNfK676AJizWLYjschd2"
+  },
+  {
+    "tag": "gag198",
+    "title": "Olga von Kiew oder Mit den Spatzen kam der Tod",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000444106397",
+    "url_spotify": "https://open.spotify.com/episode/298XSx6KlgNvrE1CgAJkVb"
+  },
+  {
+    "tag": "gag197",
+    "title": "Das kurzlebige Königreich Finnland – und ein deutscher Adliger auf dem Thron",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000443514409",
+    "url_spotify": "https://open.spotify.com/episode/4L1V6BOtmBCYeipB0S5TST"
+  },
+  {
+    "tag": "gag196",
+    "title": "Wie der Panamakanal entstand",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000442797339",
+    "url_spotify": "https://open.spotify.com/episode/1h9cCZYMnASrFfWUbyU20q"
+  },
+  {
+    "tag": "gag195",
+    "title": "Wie Gerta Stern auf der Flucht nach Panama ihren Mann aus dem KZ befreite",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000442017788",
+    "url_spotify": "https://open.spotify.com/episode/505zsY5t1hcYF1QB2DhDeC"
+  },
+  {
+    "tag": "gag194",
+    "title": "Die Natchez und der französische Kolonialismus in Nordamerika",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000441261870",
+    "url_spotify": "https://open.spotify.com/episode/6paMx5fL5mVRU6xUyjv5vS"
+  },
+  {
+    "tag": "gag193",
+    "title": "Kanton Übrig – Wie Vorarlberg 1919 nicht der Schweiz beitrat",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000440652549",
+    "url_spotify": "https://open.spotify.com/episode/2OwrFvo67U1iFbsV6Howk0"
+  },
+  {
+    "tag": "gag192",
+    "title": "Tiere vor Gericht",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000440026400",
+    "url_spotify": "https://open.spotify.com/episode/13aKee02ff9zfqquLVItZZ"
+  },
+  {
+    "tag": "gag191",
+    "title": "Aethelfled - Warrior Queen of Mercia",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000439037639",
+    "url_spotify": "https://open.spotify.com/episode/1GvFG7NmK5KEtUVvzrdSIW"
+  },
+  {
+    "tag": "gag190",
+    "title": "Die Assassinen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000438142394",
+    "url_spotify": "https://open.spotify.com/episode/6ZKhMG5jEdglyYAsnkcKiQ"
+  },
+  {
+    "tag": "gag189",
+    "title": "Die Schlacht bei Cannae",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000437494250",
+    "url_spotify": "https://open.spotify.com/episode/2aAwKocigYRFZmpon0lUYO"
+  },
+  {
+    "tag": "gag188",
+    "title": "Martin Couney und die Inkubator-Ausstellungen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000436967239",
+    "url_spotify": "https://open.spotify.com/episode/6MFw85TttCLPOVVphfhqCQ"
+  },
+  {
+    "tag": "gag187",
+    "title": "Die Wiener Weltausstellung von 1873",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000436243122",
+    "url_spotify": "https://open.spotify.com/episode/1BddsfCQlOOdy2xopoOyFd"
+  },
+  {
+    "tag": "gag186",
+    "title": "Die Redlichen Pioniere von Rochdale und eine kurze Geschichte der Genossenschaften",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000435127029",
+    "url_spotify": "https://open.spotify.com/episode/2pTXHOEEh8C4aEravQ6FN9"
+  },
+  {
+    "tag": "gag185",
+    "title": "Kleindeutschland und die General Slocum Katastrophe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000434578654",
+    "url_spotify": "https://open.spotify.com/episode/5eYMt2uJjoA7eGRfLU0zBP"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000434325316",
+    "url_spotify": "https://open.spotify.com/episode/2L09bRqv9u7KZKEyqOaX1x",
+    "title": "Revolution 1918/19 in Bayern",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag184",
+    "title": "Katharina Kepler – ein Hexenprozess in der Frühen Neuzeit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000434026525",
+    "url_spotify": "https://open.spotify.com/episode/7IYbQOhjOUVSM9Uh3tXT4A"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000433780673",
+    "url_spotify": "https://open.spotify.com/episode/7z5e4jcnxTzNPNGcoSetmR",
+    "title": "Dr. Emma Southon on Agrippina the Younger",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag183",
+    "title": "Agrippina die Jüngere, mächtigste Frau der frühen Kaiserzeit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000433565458",
+    "url_spotify": "https://open.spotify.com/episode/3gYzbBBBWHKBGG2LzSsvCu"
+  },
+  {
+    "tag": "gag182",
+    "title": "Der Zündholzkönig Ivar Kreuger",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000432471707",
+    "url_spotify": "https://open.spotify.com/episode/3S4fAHnZJPs5dm5Kuj43OG"
+  },
+  {
+    "tag": "gag181",
+    "title": "Von Gulasch, Pörkölt und Nationalgerichten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000431676040",
+    "url_spotify": "https://open.spotify.com/episode/422QlqD6qHEN4p44QMKItQ"
+  },
+  {
+    "tag": "gag180",
+    "title": "Die Gelbe Flotte – ein Schiffskonvoi zwischen den Fronten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000431200601",
+    "url_spotify": "https://open.spotify.com/episode/5TpMZvVMReA0lXiMDLSsPO"
+  },
+  {
+    "tag": "gag179",
+    "title": "Maria Sibylla Merian – Naturforscherin und Künstlerin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000430719556",
+    "url_spotify": "https://open.spotify.com/episode/7E6A9hsQCiExsRSOZvGKp1"
+  },
+  {
+    "tag": "gag178",
+    "title": "Der Klosterskandal von Sant'Ambrogio",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000430242382",
+    "url_spotify": "https://open.spotify.com/episode/4tDSryeauuSIOs6AteWmU8"
+  },
+  {
+    "tag": "gag177",
+    "title": "Robert Fortune, Botaniker und Teespion",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000429772766",
+    "url_spotify": "https://open.spotify.com/episode/2DnuYm5LH0S0DlGT4FW5kA"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000429921476",
+    "url_spotify": "https://open.spotify.com/episode/73mGGXf7QSw7eXbotzNXEO",
+    "title": "Margiana – ein Interview mit Rainer-Maria Weiss, Direktor des Archäologischen Museums in Hamburg",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag176",
+    "title": "Die Anfänge des Anarchismus und was Uhrmacher in der Schweiz damit zu tun haben",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000429294962",
+    "url_spotify": "https://open.spotify.com/episode/1tTiVaB5nK8dhlmFeVu6Jq"
+  },
+  {
+    "tag": "gag175",
+    "title": "C.W. Field und das erste Kabel durch den Atlantik",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000428771814",
+    "url_spotify": "https://open.spotify.com/episode/00wGKCs2eqyvBB34BYeDbW"
+  },
+  {
+    "tag": "gag174",
+    "title": "Harriet Tubman und die Underground Railroad",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000428302998",
+    "url_spotify": "https://open.spotify.com/episode/1HUjZ1rrvh2jmke7uLgjCi"
+  },
+  {
+    "tag": "gag173",
+    "title": "Der gefährliche Garten von Vaux-le-Vicomte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000427760439",
+    "url_spotify": "https://open.spotify.com/episode/31mk3Wah0SFjw8FKNpBFkg"
+  },
+  {
+    "tag": "gag172",
+    "title": "Eine kurze Geschichte der Armut in der Frühen Neuzeit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000427298306",
+    "url_spotify": "https://open.spotify.com/episode/3z2ZNQaAYKtCx63XQxpj8R"
+  },
+  {
+    "tag": "gag171",
+    "title": "Eine ganz kleine Geschichte der Nacht und des Schlafs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000426862065",
+    "url_spotify": "https://open.spotify.com/episode/3hdCRJtnhyMKvuil8xoDrA"
+  },
+  {
+    "tag": "gag170",
+    "title": "Auf Schatzsuche",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000426510560",
+    "url_spotify": "https://open.spotify.com/episode/6U1zjQPNqXMDnSCmiUn82m"
+  },
+  {
+    "tag": "gag169",
+    "title": "Maos Großer Sprung und die chinesische Hungersnot von 1958–62",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000426107644",
+    "url_spotify": "https://open.spotify.com/episode/5xAvIJSjNKgGoa104FPrMY"
+  },
+  {
+    "tag": "gag168",
+    "title": "Carl Laemmle und die Anfänge Hollywoods",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000425644008",
+    "url_spotify": "https://open.spotify.com/episode/3dUHpIQYSM7d0ClnusTe9C"
+  },
+  {
+    "tag": "gag167",
+    "title": "Mary Toft und die Hasen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000425183366",
+    "url_spotify": "https://open.spotify.com/episode/6ctxgWRiThdTPBxGOnFG4v"
+  },
+  {
+    "tag": "gag166",
+    "title": "Siegmund Bosel – die wechselvolle Geschichte eines Inflationskönigs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000424722902",
+    "url_spotify": "https://open.spotify.com/episode/78Ddnbu5C3HwbOXaIuczM2"
+  },
+  {
+    "tag": "gag165",
+    "title": "Pius IX. und die kurzlebige Römische Republik von 1849",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000424281431",
+    "url_spotify": "https://open.spotify.com/episode/2cT87WWeGnydYlg1eu48bt"
+  },
+  {
+    "tag": "gag164",
+    "title": "Eine kurze Geschichte des Alkoholkonsums",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000423828888",
+    "url_spotify": "https://open.spotify.com/episode/0xQIf6lNrqeegnHycv8ffA"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000423576091",
+    "url_spotify": "https://open.spotify.com/episode/38QAuVHOOndmL8TEpx1rLc",
+    "title": "Dirk Liesemer über den Aufstand der Matrosen und den Beginn der Revolution",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag163",
+    "title": "Vernepator Cur - der Hund im Hamsterrad",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000423378132",
+    "url_spotify": "https://open.spotify.com/episode/6JH4fAGaYsleYrWMfI1ogP"
+  },
+  {
+    "tag": "gag162",
+    "title": "Novemberrevolution und die mehrfache Ausrufung der Republik",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000422910993",
+    "url_spotify": "https://open.spotify.com/episode/7GVm54v1G4k0TZycBB7P6i"
+  },
+  {
+    "tag": "gag161",
+    "title": "Steamboat Arabia oder Der Schatz im Maisfeld",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000422486303",
+    "url_spotify": "https://open.spotify.com/episode/0EUXMzrSs00zJg2kl1vQxy"
+  },
+  {
+    "tag": "gag160",
+    "title": "Barbareskenstaaten und die europäischen Seemächte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000422000923",
+    "url_spotify": "https://open.spotify.com/episode/4YYxMACsJWfPMvwIgdFzb3"
+  },
+  {
+    "tag": "gag159",
+    "title": "Thorsten Logge über Geschichte und Public History",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000421480381",
+    "url_spotify": "https://open.spotify.com/episode/0TcDRNbGTeekg88P2pkCZB"
+  },
+  {
+    "tag": "gag158",
+    "title": "Al-Biruni und die erste Globalgeschichte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000420967420",
+    "url_spotify": "https://open.spotify.com/episode/03B1Ude38Ny72dQf64NUn5"
+  },
+  {
+    "tag": "gag157",
+    "title": "Salpeter – Aufstieg und Fall einer chemischen Verbindung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000420482753",
+    "url_spotify": "https://open.spotify.com/episode/4hyyLDSROsIZARmDxa2WaG"
+  },
+  {
+    "tag": "gag156",
+    "title": "Charles Lindbergh, Alexis Carrel und die Mensch-Maschine",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000420025903",
+    "url_spotify": "https://open.spotify.com/episode/4uMtrCjIunmka2EDh2KXrb"
+  },
+  {
+    "tag": "gag155",
+    "title": "Trofim Lyssenko und der Lyssenkoismus in der Sowjetunion",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000419589724",
+    "url_spotify": "https://open.spotify.com/episode/5vr1J0GDGZ8AKtITKs7QIt"
+  },
+  {
+    "tag": "gag154",
+    "title": "La Maupin, die duellierende Opernsängerin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000419145347",
+    "url_spotify": "https://open.spotify.com/episode/4jlrykohUIpbHRT1YYJYCm"
+  },
+  {
+    "tag": "gag153",
+    "title": "Wien-Tour mit Thomas Harbich (#WienFakt)",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000418706854",
+    "url_spotify": "https://open.spotify.com/episode/53yNTXgxnhuO4i5jdNSC76"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000418482330",
+    "url_spotify": "https://open.spotify.com/episode/0veKZbyqXYPisULIKim8vJ",
+    "title": "Interview mit Walfried Malleskat vom Filmmuseum Bendestorf",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag152",
+    "title": "Ernest Shackleton und die Endurance-Expedition",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000418282474",
+    "url_spotify": "https://open.spotify.com/episode/4kejB2M4UEtbk0bEaiqBbA"
+  },
+  {
+    "tag": "gag151",
+    "title": "Manjirō, der erste Japaner in Amerika",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000417848647",
+    "url_spotify": "https://open.spotify.com/episode/5rS3pJyl6OMo1zhxnMz6OR"
+  },
+  {
+    "tag": "gag150",
+    "title": "Die Geschichte des Filmstudios Bendestorf",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000417414098",
+    "url_spotify": "https://open.spotify.com/episode/74hIwlNIiu7zqVdNmKYPxD"
+  },
+  {
+    "tag": "gag149",
+    "title": "Die Kabeljaukriege",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000417000868",
+    "url_spotify": "https://open.spotify.com/episode/4r32yCQw4FRLmuAYQ6e1Sg"
+  },
+  {
+    "tag": "gag148",
+    "title": "Das Ende der Welt - Friedenskaiser und falsche Friedriche",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000416559918",
+    "url_spotify": "https://open.spotify.com/episode/2FircaU9PZL663kkcaKfM0"
+  },
+  {
+    "tag": "gag147",
+    "title": "Das Fräulein vom Amt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000416075998",
+    "url_spotify": "https://open.spotify.com/episode/2aOx0EiAsGUWf1VHUGMQZX"
+  },
+  {
+    "tag": "gag146",
+    "title": "Tripel-Allianz-Krieg",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000415604825",
+    "url_spotify": "https://open.spotify.com/episode/2SLmisehzYKl5X8pBkP9Nv"
+  },
+  {
+    "tag": "gag145",
+    "title": "Barbara von Cilli oder Wie eine 100 mal wiederholte Lüge zur Wahrheit wird",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000415200397",
+    "url_spotify": "https://open.spotify.com/episode/3tRXiBN6gdSVkrVqL8HkOo"
+  },
+  {
+    "tag": "gag144",
+    "title": "Die Spanische Grippe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000414732841",
+    "url_spotify": "https://open.spotify.com/episode/52p1h2HXYJVYA0FFeRcEy3"
+  },
+  {
+    "tag": "gag143",
+    "title": "Über Marsmenschen, Massenpanik und die Entstehung eines Mythos",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000414200492",
+    "url_spotify": "https://open.spotify.com/episode/3hfe6cGkrojhSrsD3IlUYp"
+  },
+  {
+    "tag": "gag142",
+    "title": "Bertha Pappenheim – Gründerin des Jüdischen Frauenbundes und Sozialpionierin",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000413633779",
+    "url_spotify": "https://open.spotify.com/episode/6XwFMUROs8sBbcaI0Lnx7D"
+  },
+  {
+    "tag": "gag141",
+    "title": "Die kurze Geschichte des Kokovorismus",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000413127578",
+    "url_spotify": "https://open.spotify.com/episode/0Z3Q4EitG8hfh4dzOaPkN9"
+  },
+  {
+    "tag": "gag140",
+    "title": "Eisbrecher für die Diplomatie – das Fußball-Länderspiel Sowjetunion gegen die BRD 1955",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000412551348",
+    "url_spotify": "https://open.spotify.com/episode/5zM22GNYqBp4hnCBy9f5Uo"
+  },
+  {
+    "tag": "gag139",
+    "title": "Als Voltaire die Lotterie knackte und steinreich wurde",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000412192106",
+    "url_spotify": "https://open.spotify.com/episode/4qxLgkZAuOxKKwqlquQeYo"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000411916026",
+    "url_spotify": "https://open.spotify.com/episode/3xKzOt38mOf2qeGtVdBxSy",
+    "title": "Interview mit Historiker Jürgen Zimmerer über Kolonialgeschichte",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag138",
+    "title": "Askari und die Kolonialgeschichte des Deutschen Reichs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000411669626",
+    "url_spotify": "https://open.spotify.com/episode/2VLfXemiSqxOdztongvQho"
+  },
+  {
+    "tag": "gag137",
+    "title": "Die Französisch-Britische Union",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000411014250",
+    "url_spotify": "https://open.spotify.com/episode/274VGAWjCVzoIYo2d5vPDp"
+  },
+  {
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000410850976",
+    "url_spotify": "https://open.spotify.com/episode/7Atwlg4oByTGholJZLLXlJ",
+    "title": "Die gesamte Führung durch den Jüdischen Friedhof Währing",
+    "tag": "extra"
+  },
+  {
+    "tag": "gag136",
+    "title": "Der Jüdische Friedhof Währing",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000410449590",
+    "url_spotify": "https://open.spotify.com/episode/0u6ZwmNQVE1kSlbGBoQuyC"
+  },
+  {
+    "tag": "gag135",
+    "title": "Adolf Loos",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000409797595",
+    "url_spotify": "https://open.spotify.com/episode/4RX2W1Ml6z0OVwIiBddWbK"
+  },
+  {
+    "tag": "gag134",
+    "title": "Eine kleine Geschichte des Kaiserschnitts anhand der Personen Jacob Nufer, James Barry und Margret Ann Bulkley",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000409132953",
+    "url_spotify": "https://open.spotify.com/episode/4LBZskdx4nJpC0NWvOl7QL"
+  },
+  {
+    "tag": "gag133",
+    "title": "Alexios Komnenos und der Erste Kreuzzug",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000408651056",
+    "url_spotify": "https://open.spotify.com/episode/35xYH882tbbv2o0CA2l2o9"
+  },
+  {
+    "tag": "gag132",
+    "title": "Gesche Gottfried, der Engel von Bremen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000408132127",
+    "url_spotify": "https://open.spotify.com/episode/38H47XxnVO8YSwwM0rGe14"
+  },
+  {
+    "tag": "gag131",
+    "title": "Strathclyde – ein (fast) vergessenes Königreich",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000407654746",
+    "url_spotify": "https://open.spotify.com/episode/65vHsS9k0eosgg4PhpovUy"
+  },
+  {
+    "tag": "gag130",
+    "title": "Alexander von Abonuteichos oder Wie ein Kult entsteht",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000407031552",
+    "url_spotify": "https://open.spotify.com/episode/49AsgkN6GTXw5ZcjHhd0Mn"
+  },
+  {
+    "tag": "gag129",
+    "title": "Die Entdeckung der Dinosaurier",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000406331495",
+    "url_spotify": "https://open.spotify.com/episode/4Haz7sgcPJyyb2qRClHg3f"
+  },
+  {
+    "tag": "gag128",
+    "title": "Crash at Crush",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000405239180",
+    "url_spotify": "https://open.spotify.com/episode/4ygYmihhhgPzDm5wGYT1BK"
+  },
+  {
+    "tag": "gag127",
+    "title": "Struensee – Aufstieg und Fall eines Arztes, der (für kurze Zeit) zum dänischen Regenten wurde",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000404146589",
+    "url_spotify": "https://open.spotify.com/episode/29d5XY1lw5t2vWSOPIfp29"
+  },
+  {
+    "tag": "gag126",
+    "title": "Für immer im Eis – die Franklin Expedition",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000403212378",
+    "url_spotify": "https://open.spotify.com/episode/5e0y9IoQ5pd3k2NVVQPREF"
+  },
+  {
+    "tag": "gag125",
+    "title": "Republik Fredonia",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000402295313",
+    "url_spotify": "https://open.spotify.com/episode/6dnFW9f1FrGXVdEbAtXOOW"
+  },
+  {
+    "tag": "gag124",
+    "title": "Eine kleine Geschichte des Chinese Restaurant Syndroms",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000401670816",
+    "url_spotify": "https://open.spotify.com/episode/0q7nTK3vn4KNdxZc5BXj4o"
+  },
+  {
+    "tag": "gag123",
+    "title": "Christian Gottlieb Prieber – Aussteiger, Renegade und beinahe vergessener Utopist",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000401118688",
+    "url_spotify": "https://open.spotify.com/episode/4QbToGe3VWy7q0fgYWozw6"
+  },
+  {
+    "tag": "gag122",
+    "title": "Die Belagerung von Masada",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000400584272",
+    "url_spotify": "https://open.spotify.com/episode/0PzBVeyiuTgRcM6ppg0laW"
+  },
+  {
+    "tag": "gag121",
+    "title": "Leopardenmorde und Leopardenmenschen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000400043163",
+    "url_spotify": "https://open.spotify.com/episode/7kKxznbYoeehz6duoj5qcH"
+  },
+  {
+    "tag": "gag120",
+    "title": "Die Rückkehr des Martin Guerre",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000399513604",
+    "url_spotify": "https://open.spotify.com/episode/4tgtmIJDl4vpZxJ9bPUeug"
+  },
+  {
+    "tag": "gag119",
+    "title": "Die NS-Thingbewegung - Thingstätten und Thingspiele",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000398978353",
+    "url_spotify": "https://open.spotify.com/episode/1VB7hocOnWIMnBpDuZyKFG"
+  },
+  {
+    "tag": "gag118",
+    "title": "Ein Werwolf in Livland",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000398482816",
+    "url_spotify": "https://open.spotify.com/episode/6B0Zki8ejykxRiYActHEfL"
+  },
+  {
+    "tag": "gag117",
+    "title": "Tunix, Tuwat und die Entstehung des Chaos Computer Clubs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000397865041",
+    "url_spotify": "https://open.spotify.com/episode/19JOuGadTlRlmQQiUkyJg4"
+  },
+  {
+    "tag": "gag116",
+    "title": "Über Basken, Wale und ein Massaker auf Island",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000397213121",
+    "url_spotify": "https://open.spotify.com/episode/2oijaxCGn3RI0dPuJCXPIw"
+  },
+  {
+    "tag": "gag115",
+    "title": "Eine kurze Geschichte der Hanse",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000396512110",
+    "url_spotify": "https://open.spotify.com/episode/2Zqj4mNgPRY2OATuN624Q0"
+  },
+  {
+    "tag": "gag114",
+    "title": "Gerhard Zucker und sein Raketentraum",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000395406934",
+    "url_spotify": "https://open.spotify.com/episode/4LrohfQExYe1KvgDQ5TW8X"
+  },
+  {
+    "tag": "gag113",
+    "title": "Die Hep-Hep-Unruhen von 1819",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000395127378",
+    "url_spotify": "https://open.spotify.com/episode/1Ag57emcetM0VP2H6nHpvH"
+  },
+  {
+    "tag": "gag112",
+    "title": "Adele Spitzeder und die 'Dachauer Bank'",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000394831834",
+    "url_spotify": "https://open.spotify.com/episode/7BH6zSd39SjrlU86xhdgoA"
+  },
+  {
+    "tag": "gag111",
+    "title": "Die Anfänge des Esperanto",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000394557748",
+    "url_spotify": "https://open.spotify.com/episode/5lNq6xvACGdDEirTFvdgTY"
+  },
+  {
+    "tag": "gag110",
+    "title": "110, 112, 999, etc.",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000394273581",
+    "url_spotify": "https://open.spotify.com/episode/7FboByt5Ka4n9gUfcMEw9N"
+  },
+  {
+    "tag": "gag109",
+    "title": "Der Lotterieaufstand in Albanien",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393989509",
+    "url_spotify": "https://open.spotify.com/episode/6K1ZC7FNxzXSPKz7BUgKT4"
+  },
+  {
+    "tag": "gag108",
+    "title": "Der Paderborner Kaffeelärm",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393675793",
+    "url_spotify": "https://open.spotify.com/episode/0K52P0WwyfVaFDqC44kO4A"
+  },
+  {
+    "tag": "gag107",
+    "title": "Eine kurze Geschichte der Guillotine",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393336380",
+    "url_spotify": "https://open.spotify.com/episode/0gUaw16rgtUsjnYBzTifwV"
+  },
+  {
+    "tag": "gag106",
+    "title": "Das Darién-Projekt und seine Folgen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000393059858",
+    "url_spotify": "https://open.spotify.com/episode/2dkRNKqAB6LVqZGsKLgjEG"
+  },
+  {
+    "tag": "gag105",
+    "title": "Skanderberg - Ein neuer Alexander und seine Bedeutung für die Geschichte Albaniens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000392769311",
+    "url_spotify": "https://open.spotify.com/episode/3AFWN32zUunBBExVqjVKiG"
+  },
+  {
+    "tag": "gag104",
+    "title": "Crécy - Chronik eines Versagens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000392482829",
+    "url_spotify": "https://open.spotify.com/episode/0hcUQ7KLmOvCIT8547IRmu"
+  },
+  {
+    "tag": "gag103",
+    "title": "Demoskopie - eine kurze Geschichte der (politischen) Meinungsforschung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000392200591",
+    "url_spotify": "https://open.spotify.com/episode/0PtVIHp9roLDN04XXIlO5e"
+  },
+  {
+    "tag": "gag102",
+    "title": "Ein Picknick, das die Welt veränderte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391906949",
+    "url_spotify": "https://open.spotify.com/episode/4vXMrFLnYQtiFtB4VkODsn"
+  },
+  {
+    "tag": "gag101",
+    "title": "Leon Theremin - Was die Anfänge der elektronischen Musik mit Überwachungstechniken zu tun haben",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391634414",
+    "url_spotify": "https://open.spotify.com/episode/4Wu2EjiZXiiaMU9eiw8Yqr"
+  },
+  {
+    "tag": "gag100",
+    "title": "Der Fall der 'Mignonette' und seine Folgen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391371034",
+    "url_spotify": "https://open.spotify.com/episode/7zYCafqO58iWoLugjzcSxw"
+  },
+  {
+    "tag": "gag99",
+    "title": "Ignaz Semmelweis und die Bekämpfung des Kinderbettfiebers",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000391108108",
+    "url_spotify": "https://open.spotify.com/episode/1LJSNilwfXltmVZeYvp3rl"
+  },
+  {
+    "tag": "gag98",
+    "title": "Über Schoßhunde und gierige Affen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390832808",
+    "url_spotify": "https://open.spotify.com/episode/2QzvA5M6eSznw0fpoc5M7U"
+  },
+  {
+    "tag": "gag97",
+    "title": "Neutral-Moresnet - Ein Niemandsland mitten in Europa",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390573702",
+    "url_spotify": "https://open.spotify.com/episode/468ro0imwh6SDTMqBOUhcK"
+  },
+  {
+    "tag": "gag96",
+    "title": "Von der Entstehung des Croissants und anderen kulinarischen Mythen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390368953",
+    "url_spotify": "https://open.spotify.com/episode/4fiuElrnuiZSHWyFGFLXqM"
+  },
+  {
+    "tag": "gag95",
+    "title": "Der Aufstieg des Jakob Fugger",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000390055312",
+    "url_spotify": "https://open.spotify.com/episode/5GnPKIQUIEFeviWKICACdf"
+  },
+  {
+    "tag": "gag94",
+    "title": "Wer zitter nicht vor den Mohocks?",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000389814986",
+    "url_spotify": "https://open.spotify.com/episode/3OQ2iq4EQc4cMbCp0Kn5he"
+  },
+  {
+    "tag": "gag93",
+    "title": "Das Geheimnis des Lebens - Wie es zur Entdeckung der Doppelhelix kam",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000389551654",
+    "url_spotify": "https://open.spotify.com/episode/79RGe9UIQSOw8Q8msjKLkf"
+  },
+  {
+    "tag": "gag92",
+    "title": "Die Geschichte der Typhoid Mary",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000389275925",
+    "url_spotify": "https://open.spotify.com/episode/4nBfBgw3EScKx7m4CqQvJj"
+  },
+  {
+    "tag": "gag91",
+    "title": "Jan van Eyck - Der König unter den Malern und die Erfindung des Gemäldes",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000388295335",
+    "url_spotify": "https://open.spotify.com/episode/3nupJ8jAKOBQdcdOjolALg"
+  },
+  {
+    "tag": "gag90",
+    "title": "Aufstieg und Fall des Roger Casement",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000386549733",
+    "url_spotify": "https://open.spotify.com/episode/6uO4msqtDmBm6Wkw4IP3kh"
+  },
+  {
+    "tag": "gag89",
+    "title": "Seelenkonskription - die Anfänge der modernen Volkszählungen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000386385230",
+    "url_spotify": "https://open.spotify.com/episode/2GqFnonR6sTTg14w9f9eiz"
+  },
+  {
+    "tag": "gag88",
+    "title": "Von der Tanzwut und ihrer (wahrscheinlichen) Ursache",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000386109986",
+    "url_spotify": "https://open.spotify.com/episode/5GG02QnjGbLA5CbsFQEYYY"
+  },
+  {
+    "tag": "gag87",
+    "title": "Die Einführung von Freigeld und das Wunder von Wörgl",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385867963",
+    "url_spotify": "https://open.spotify.com/episode/5hFUgLcljk5jgTIW48Jq0H"
+  },
+  {
+    "tag": "gag86",
+    "title": "Sabbatai Zwi - Der falsche Messias",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385624258",
+    "url_spotify": "https://open.spotify.com/episode/2O0TN6l3XMcvPGfEffVfgx"
+  },
+  {
+    "tag": "gag85",
+    "title": "Ein Arm, ein Hai, ein Kriminalfall",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385388548",
+    "url_spotify": "https://open.spotify.com/episode/0IVcUOqpO8gdRui1TZVid2"
+  },
+  {
+    "tag": "gag84",
+    "title": "Eine kleine Geschichte des Klimas und des Klimawandels",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000385153953",
+    "url_spotify": "https://open.spotify.com/episode/1LFYZrfx8wccEjTEfJhBNa"
+  },
+  {
+    "tag": "gag83",
+    "title": "100 Jahre vor der Reformation - Jan Hus und die Hussitenkriege",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384894569",
+    "url_spotify": "https://open.spotify.com/episode/1sVRLs1J9M5KOjeqalH0ew"
+  },
+  {
+    "tag": "gag82",
+    "title": "Victor Gruen und die Erfindung des Einkaufszentrums",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384652927",
+    "url_spotify": "https://open.spotify.com/episode/6k5MyhZflO7WFtWVBYfY9y"
+  },
+  {
+    "tag": "gag81",
+    "title": "Eine kurze Geschichte des Essbestecks (aber ohne Löffel)",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384405149",
+    "url_spotify": "https://open.spotify.com/episode/4l2j17NMRk5ARzBBfXcNBn"
+  },
+  {
+    "tag": "gag80",
+    "title": "Eine Kirche auf dem Dachboden - Reformation und das Goldene Zeitalter in den Niederlanden",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000384136524",
+    "url_spotify": "https://open.spotify.com/episode/4gH9GqNidBU2i3qmMVNkQD"
+  },
+  {
+    "tag": "gag79",
+    "title": "Das Rolandslied - über Heldentaten, Karl den Großen und Kreuzzugpropaganda",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000383268304",
+    "url_spotify": "https://open.spotify.com/episode/4vhSVl2ksQShTMmBicbBsF"
+  },
+  {
+    "tag": "gag78",
+    "title": "Eine kurze Geschichte der Sommerzeit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382960991",
+    "url_spotify": "https://open.spotify.com/episode/4g9YsUJ6p0YjKAKMufl4Av"
+  },
+  {
+    "tag": "gag77",
+    "title": "Der Augsburger Kalenderstreit: Folgen eines tatsächlichen Zeitsprungs",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382660953",
+    "url_spotify": "https://open.spotify.com/episode/3GlAh2eIIxeSDs14E6kACK"
+  },
+  {
+    "tag": "gag76",
+    "title": "Holdouts - Japans vergessene Soldaten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382352420",
+    "url_spotify": "https://open.spotify.com/episode/5W5s6cr971joBMVk4wsJGy"
+  },
+  {
+    "tag": "gag75",
+    "title": "Sobhuza II., König von Swaziland",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000382049102",
+    "url_spotify": "https://open.spotify.com/episode/7dmnWLCRuFvjNzouKx5a2n"
+  },
+  {
+    "tag": "gag74",
+    "title": "Die Bonnot-Bande und die Erfindung des Fluchtautos",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000381751312",
+    "url_spotify": "https://open.spotify.com/episode/6GZkkxOTMmDoryaq6Wi5uQ"
+  },
+  {
+    "tag": "gag73",
+    "title": "Ludwig XIV. und seine pikante Operation",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000381245027",
+    "url_spotify": "https://open.spotify.com/episode/3lPJcz6bnmPzBw2AsL3gnB"
+  },
+  {
+    "tag": "gag72",
+    "title": "Phantominseln",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380961719",
+    "url_spotify": "https://open.spotify.com/episode/2p9X8ZWXwsvmVRhpFd0s6b"
+  },
+  {
+    "tag": "gag71",
+    "title": "Wie die Kartoffel nach Europa kam (und alles veränderte)",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380668083",
+    "url_spotify": "https://open.spotify.com/episode/0HZ3M389Q7riT5kOnqviYg"
+  },
+  {
+    "tag": "gag70",
+    "title": "Die Würzburger Lügensteine",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380394299",
+    "url_spotify": "https://open.spotify.com/episode/0KOIu4vHxSlrRiAroa9J1e"
+  },
+  {
+    "tag": "gag69",
+    "title": "Die Boston Melasse Katastrophe",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000380126837",
+    "url_spotify": "https://open.spotify.com/episode/7f8q2497JfN88U3Y7nLiEH"
+  },
+  {
+    "tag": "gag68",
+    "title": "Eine ganz kleine Geschichte der Mikroskopie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379845284",
+    "url_spotify": "https://open.spotify.com/episode/62mjsecx5Av3rdYKm8a0Du"
+  },
+  {
+    "tag": "gag67",
+    "title": "Palladio, der erfolgreichste Architekt aller Zeiten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379630652",
+    "url_spotify": "https://open.spotify.com/episode/0RiMr1rhC42ICD8Ox1ooPB"
+  },
+  {
+    "tag": "gag66",
+    "title": "Der Aufstieg Hamburgs- Fake it 'til you make it",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379398801",
+    "url_spotify": "https://open.spotify.com/episode/4PDp0DZl0AlqrXQEYv5RI3"
+  },
+  {
+    "tag": "gag65",
+    "title": "Die Erfindung des diamantenen Verlobungsrings",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000379203346",
+    "url_spotify": "https://open.spotify.com/episode/2cgTduXwfUeaJVzcVEVsBb"
+  },
+  {
+    "tag": "gag64",
+    "title": "Paul Dirac und die Schönheit der Mathematik",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378982662",
+    "url_spotify": "https://open.spotify.com/episode/2dc9AUzVeH7Xup0k6KrRpo"
+  },
+  {
+    "tag": "gag63",
+    "title": "Konstantin und die Janitscharen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378717815",
+    "url_spotify": "https://open.spotify.com/episode/2s7KEZmGwDSE8simg0wgAm"
+  },
+  {
+    "tag": "gag62",
+    "title": "Eine kurze Geschichte der Rollschuhe und des Rollschuhfahrens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378437955",
+    "url_spotify": "https://open.spotify.com/episode/5Dv7XJiEjS0v0JWxqvvB01"
+  },
+  {
+    "tag": "gag61",
+    "title": "Die niederländische 'Tulpenmanie' (und warum sie gar nicht so schlimm war)",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000378200683",
+    "url_spotify": "https://open.spotify.com/episode/2mdw5slqoOUiQ2qCJxWJfN"
+  },
+  {
+    "tag": "gag60",
+    "title": "Wie das Essengehen erfunden wurde",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377932182",
+    "url_spotify": "https://open.spotify.com/episode/5Fg96tVbHxEwLxH3YNj75A"
+  },
+  {
+    "tag": "gag59",
+    "title": "The Lost Colony",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377684758",
+    "url_spotify": "https://open.spotify.com/episode/0fdYpNwTWATYoCzKasdfwE"
+  },
+  {
+    "tag": "gag58",
+    "title": "Londoner Kutschenstreit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377431298",
+    "url_spotify": "https://open.spotify.com/episode/57GHnY257TIXPYQ1rkLHGq"
+  },
+  {
+    "tag": "gag57",
+    "title": "Von Grabtüchern, Knochen und wieder mal Venedig",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000377156069",
+    "url_spotify": "https://open.spotify.com/episode/4IFjipZWkWjaUyXoEhujRM"
+  },
+  {
+    "tag": "gag56",
+    "title": "Piggly Wiggly und die Geschichte des Supermarkts",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000376858721",
+    "url_spotify": "https://open.spotify.com/episode/4y4EKtR3q0LTs16aM2hTkL"
+  },
+  {
+    "tag": "gag55",
+    "title": "Der letzte Kammerdiener des alten Kaisers",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000376538016",
+    "url_spotify": "https://open.spotify.com/episode/3mqHGEYQdnor31jmkAg054"
+  },
+  {
+    "tag": "gag54",
+    "title": "Die erste Rektorin einer deutschen Universität",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000376235801",
+    "url_spotify": "https://open.spotify.com/episode/1fIiWyfEkK9E9yoq5e4yTc"
+  },
+  {
+    "tag": "gag53",
+    "title": "Ein Verrat und ein langer Strich auf der Berliner Mauer",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375932154",
+    "url_spotify": "https://open.spotify.com/episode/5SapwNpGIpWbXN5m3tcF28"
+  },
+  {
+    "tag": "gag52",
+    "title": "Die Geschichte der Annie Londonderry, 'New Woman' und Fahrradweltreisende",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375561576",
+    "url_spotify": "https://open.spotify.com/episode/6TS6XpIbA1bcyyKpKBBhoh"
+  },
+  {
+    "tag": "gag51",
+    "title": "Eine kurze Geschichte der Rhythmologie und der Erforschung des Herzens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375305415",
+    "url_spotify": "https://open.spotify.com/episode/2M9A42QccAi1wSEUeWHQpV"
+  },
+  {
+    "tag": "gag50",
+    "title": "Ossian, ein altgälisches Epos wie keines davor",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000375026008",
+    "url_spotify": "https://open.spotify.com/episode/1y3v0w0AKfa7SdO3KMG1Mc"
+  },
+  {
+    "tag": "gag49",
+    "title": "Der 'Dig Tree' und die erste Durchquerung Australiens",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000374763865",
+    "url_spotify": "https://open.spotify.com/episode/7peM2oyLO8ZKY3u4WpsZIT"
+  },
+  {
+    "tag": "gag48",
+    "title": "George Ansons katastrophale Expedition",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000374536825",
+    "url_spotify": "https://open.spotify.com/episode/2TkSGKH5blxHXQ01aAn0eW"
+  },
+  {
+    "tag": "gag47",
+    "title": "Die Schwabenkinder und ihre Geschichte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000374229545",
+    "url_spotify": "https://open.spotify.com/episode/6dQFSMSiSnDXPgUYpiXJ2k"
+  },
+  {
+    "tag": "gag46",
+    "title": "Aufstieg und Fall der Republik Ragusa",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000373904462",
+    "url_spotify": "https://open.spotify.com/episode/0ktlpREDhRYFJFNMXtuvGW"
+  },
+  {
+    "tag": "gag45",
+    "title": "Zwentendorf - Das sicherste Kernkraftwerk der Welt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000373601309",
+    "url_spotify": "https://open.spotify.com/episode/0MQVQ0SHPNQ15sN2KhbM7x"
+  },
+  {
+    "tag": "gag44",
+    "title": "Eine kurze Geschichte der Süßigkeiten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000373059040",
+    "url_spotify": "https://open.spotify.com/episode/0GEWYdE9J1XrNHsXBQoGhJ"
+  },
+  {
+    "tag": "gag43",
+    "title": "Josef Eisemann, Seiltänzer in Wien",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000372823671",
+    "url_spotify": "https://open.spotify.com/episode/2NZOCeCcJl438EM7gCSx4N"
+  },
+  {
+    "tag": "gag42",
+    "title": "The City of Roses - Ein Rosengarten für Portland",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000372341809",
+    "url_spotify": "https://open.spotify.com/episode/17hMeVKZgYymE7anl1CjCj"
+  },
+  {
+    "tag": "gag41",
+    "title": "Der Wiener Kreis und die Ermordung von Moritz Schlick",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000371884972",
+    "url_spotify": "https://open.spotify.com/episode/5zgYBqbxtv4rafdWAEglfX"
+  },
+  {
+    "tag": "gag40",
+    "title": "Über den Ursprung der Seidenstraße",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000371475561",
+    "url_spotify": "https://open.spotify.com/episode/7o7nnbR9xKSNFpCLAZe394"
+  },
+  {
+    "tag": "gag39",
+    "title": "Die Legion Erzengel Michael und Corneliu Codreanu",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000371062610",
+    "url_spotify": "https://open.spotify.com/episode/4GwfbJ4dH7ATHkqHd2BDCD"
+  },
+  {
+    "tag": "gag38",
+    "title": "Eine kurze Geschichte der Leibeigenschaft",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000370597666",
+    "url_spotify": "https://open.spotify.com/episode/35Bb45qDhB3ABbjGJ1Z7xO"
+  },
+  {
+    "tag": "gag37",
+    "title": "Eine Reise um die Welt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000370126493",
+    "url_spotify": "https://open.spotify.com/episode/69SqnOPmWsdYnB4HHUMTYk"
+  },
+  {
+    "tag": "gag36",
+    "title": "Eine sehr kurze Geschichte des Deodorants",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000369653738",
+    "url_spotify": "https://open.spotify.com/episode/1dYCRs5hj0vou7u8w67Muh"
+  },
+  {
+    "tag": "gag35",
+    "title": "Magia Posthuma - Vampirismus in den Zeiten der Aufklärung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000369194979",
+    "url_spotify": "https://open.spotify.com/episode/569BgwkAlPOQNu4KbIIJJt"
+  },
+  {
+    "tag": "gag34",
+    "title": "Tee, Silber und Rauschmittel",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000368858130",
+    "url_spotify": "https://open.spotify.com/episode/3aKv2pBWWfcSVMjpqVAtcj"
+  },
+  {
+    "tag": "gag33",
+    "title": "Curta - eine Rechenmaschine und ihre Geschichte",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000368309600",
+    "url_spotify": "https://open.spotify.com/episode/5ojlO6FWbA4C20uKBbU8yp"
+  },
+  {
+    "tag": "gag32",
+    "title": "Henry Gunther",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000367955989",
+    "url_spotify": "https://open.spotify.com/episode/0ziTikri0S4UTavurCr8XG"
+  },
+  {
+    "tag": "gag31",
+    "title": "Blitzkrieg im Fußballstadion",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000367480748",
+    "url_spotify": "https://open.spotify.com/episode/4FrToSJ13FiZwC7ytHLk7e"
+  },
+  {
+    "tag": "gag30",
+    "title": "Wie die Zeit zu unserer wurde",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000367043045",
+    "url_spotify": "https://open.spotify.com/episode/3Le6OFVfsm3F9bgD2l6L9t"
+  },
+  {
+    "tag": "gag29",
+    "title": "Ein Müller in den Fängen der Inquisition",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000366607746",
+    "url_spotify": "https://open.spotify.com/episode/36Ans1qAdipWgZsPzFYG4t"
+  },
+  {
+    "tag": "gag28",
+    "title": "Von Appenzellern, Bregenzern und einer Frau names Guta",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000366163176",
+    "url_spotify": "https://open.spotify.com/episode/5yAE4vQZqYSIvwi7PGNYdP"
+  },
+  {
+    "tag": "gag27",
+    "title": "Die Rote Zora und ihre Vorfahren",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000365785209",
+    "url_spotify": "https://open.spotify.com/episode/7bTAEmD4kC0rXMC4Z9QOcx"
+  },
+  {
+    "tag": "gag26",
+    "title": "Wie der Champagner zu seinen Bläschen kam",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000365199724",
+    "url_spotify": "https://open.spotify.com/episode/4wdfjAlHgvM5eo7ns867qr"
+  },
+  {
+    "tag": "gag25",
+    "title": "Eine kaiserliche Bibliothek des Menschengeschlechts",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000364783840",
+    "url_spotify": "https://open.spotify.com/episode/2mBnZqrkj3enlRDhshMBQ3"
+  },
+  {
+    "tag": "gag24",
+    "title": "A French Connection, zum Scheitern verurteilt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000364342418",
+    "url_spotify": "https://open.spotify.com/episode/60oDLT7NGLEoDUKTm0tkvq"
+  },
+  {
+    "tag": "gag23",
+    "title": "Ziemlich beste Feindschaft",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000363885036",
+    "url_spotify": "https://open.spotify.com/episode/0BOZqPVfdzHB0RX8qwcAKn"
+  },
+  {
+    "tag": "gag22",
+    "title": "Vom Goldjungen zum Staatsgefangenen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000363400232",
+    "url_spotify": "https://open.spotify.com/episode/55tuPyFsS55oEJvW02II82"
+  },
+  {
+    "tag": "gag21",
+    "title": "Von der Erfindung der Einbauküche",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000362950918",
+    "url_spotify": "https://open.spotify.com/episode/26OMG7KLf5vD1jYHY7gvTO"
+  },
+  {
+    "tag": "gag20",
+    "title": "Von Drachenknochen und Schildkrötenorakeln",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000362387773",
+    "url_spotify": "https://open.spotify.com/episode/2wZr4n7gJxw0s3IsUsP1ZZ"
+  },
+  {
+    "tag": "gag19",
+    "title": "Wenn ein Wissenschaftler an Drachen glaubt",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000361702515",
+    "url_spotify": "https://open.spotify.com/episode/1Ej4mZ8G9XGsUSOE6iT7M9"
+  },
+  {
+    "tag": "gag18",
+    "title": "Wie Russland den Bart verlor",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000361255781",
+    "url_spotify": "https://open.spotify.com/episode/2HcUi5B4wzj2vuaMnmbV99"
+  },
+  {
+    "tag": "gag17",
+    "title": "Eine Urkunde, ein Zeltlager und eine Fälschung",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000360826303",
+    "url_spotify": "https://open.spotify.com/episode/14jBSIe5bjsbUafniFoCin"
+  },
+  {
+    "tag": "gag16",
+    "title": "Ton, Steine, Scherben oder wie Rom sich einen achten Hügel baute",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000360420675",
+    "url_spotify": "https://open.spotify.com/episode/0hvwzNXrxApvi5sTZfnS8F"
+  },
+  {
+    "tag": "gag15",
+    "title": "Das Mailüfterl",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000360006419",
+    "url_spotify": "https://open.spotify.com/episode/2Yk2X5TrOBDDlwpkOrUTVY"
+  },
+  {
+    "tag": "gag14",
+    "title": "Ein englisches Atlantis",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000359696165",
+    "url_spotify": "https://open.spotify.com/episode/5bqwI3qiqMswvWHgp0INYv"
+  },
+  {
+    "tag": "gag13",
+    "title": "Ein Spionagefall erschüttert die Habsburger Monarchie",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000359300003",
+    "url_spotify": "https://open.spotify.com/episode/2v6tqvI7CdTJa9F02gtYjB"
+  },
+  {
+    "tag": "gag12",
+    "title": "Ein Kaiser, ein Gott, viele Todesfälle",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000358875914",
+    "url_spotify": "https://open.spotify.com/episode/2RSruQHsfNLa6yKdtMiDXF"
+  },
+  {
+    "tag": "gag11",
+    "title": "Von Kindern und Kegeln",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000358457200",
+    "url_spotify": "https://open.spotify.com/episode/3irhNgBuWH7YtFT6MPNjXC"
+  },
+  {
+    "tag": "gag10",
+    "title": "Craigslist in der Frühen Neuzeit",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000358051702",
+    "url_spotify": "https://open.spotify.com/episode/4vqNH3KZDEUkIcG0izbMgn"
+  },
+  {
+    "tag": "gag9",
+    "title": "Wer den englischen Parlamentsbrand auf dem Kerbholz hat",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000357623768",
+    "url_spotify": "https://open.spotify.com/episode/2hecJlymUeMQlToqtBgBuz"
+  },
+  {
+    "tag": "gag8",
+    "title": "Herr der Fliegen",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000357222331",
+    "url_spotify": "https://open.spotify.com/episode/4Dfo4Dib61XYhRc40hZydl"
+  },
+  {
+    "tag": "gag7",
+    "title": "Geteilte Habsburger",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000356686509",
+    "url_spotify": "https://open.spotify.com/episode/4B3UCglSP0F1GJuJZDDdH3"
+  },
+  {
+    "tag": "gag6",
+    "title": "Ada und die Pferdewetten",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000356103093",
+    "url_spotify": "https://open.spotify.com/episode/4nS64s7eiFYeXiYiCK24gB"
+  },
+  {
+    "tag": "gag5",
+    "title": "Lernen Sie Geschichte!",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000355466179",
+    "url_spotify": "https://open.spotify.com/episode/5K0LHcD6nvsb4ZUtTxBrQJ"
+  },
+  {
+    "tag": "gag4",
+    "title": "Wellingtons Rache, oder: Ein Bein für ein Königreich",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000354819402",
+    "url_spotify": "https://open.spotify.com/episode/4AOG0wWu7sdF5ap7yHhmsy"
+  },
+  {
+    "tag": "gag3",
+    "title": "Fitness-Parcours für den Pharao",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000354603876",
+    "url_spotify": "https://open.spotify.com/episode/1k2l2ZOyUgqdxkIPVuDeC9"
+  },
+  {
+    "tag": "gag2",
+    "title": "Tatortschau mit Wiedererkennungswert",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000354056193",
+    "url_spotify": "https://open.spotify.com/episode/2TFcFH2nTYXMX7od8sw3cp"
+  },
+  {
+    "tag": "gag1",
+    "title": "Vier Langobarden-Könige und ein Trinkbecher",
+    "url_apple_podcasts": "https://podcasts.apple.com/de/podcast/geschichten-aus-der-geschichte/id1044844618?i=1000353743751",
+    "url_spotify": "https://open.spotify.com/episode/3RQ14uPgwzFjCxXhahKrTH"
+  }
+]

--- a/src/join_episodes.clj
+++ b/src/join_episodes.clj
@@ -43,7 +43,7 @@
          (episode-unique? new-episode))))
 
 (if (valid-episode?)
-  (let [all-episodes (conj all-json (merge newest-apple-podcasts-episode-json newest-spotify-episode-json))]
-    (spit "data.json" (json/generate-string (reverse all-episodes) {:pretty true})))
+  (let [all-episodes (cons (merge newest-apple-podcasts-episode-json newest-spotify-episode-json) all-json)]
+    (spit "data.json" (json/generate-string all-episodes {:pretty true})))
   (throw (ex-info "Tags don't match" {:tag-apple-podcasts (:tag newest-apple-podcasts-episode-json)
                                       :tag-spotify (:tag newest-spotify-episode-json)})))


### PR DESCRIPTION
- Changed the way new episodes are added to the all-episodes list from `conj` to `cons` to maintain the correct order.
- Updated the JSON output to reflect the new episode structure without reversing the list.
